### PR TITLE
Add chained data filesystem

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,16 +32,16 @@ lint-py:  ## lint python with ruff
 	cargo clippy --workspace --all-targets -- -D warnings
 
 lint-docs:  ## lint docs with mdformat and codespell
-	python -m mdformat --check README.md docs/tutorial.md docs/how-to-integrate.md docs/explanation.md docs/api.md
-	python -m codespell_lib README.md docs/tutorial.md docs/how-to-integrate.md docs/explanation.md docs/api.md
+	python -m mdformat --check README.md docs/tutorial.md docs/how-to-integrate.md docs/how-to-chain-filesystems.md docs/explanation.md docs/api.md
+	python -m codespell_lib README.md docs/tutorial.md docs/how-to-integrate.md docs/how-to-chain-filesystems.md docs/explanation.md docs/api.md
 
 fix-py:  ## autoformat python code with ruff
 	python -m ruff check --fix fsspec_data
 	python -m ruff format fsspec_data
 
 fix-docs:  ## autoformat docs with mdformat and codespell
-	python -m mdformat README.md docs/tutorial.md docs/how-to-integrate.md docs/explanation.md docs/api.md
-	python -m codespell_lib --write README.md docs/tutorial.md docs/how-to-integrate.md docs/explanation.md docs/api.md
+	python -m mdformat README.md docs/tutorial.md docs/how-to-integrate.md docs/how-to-chain-filesystems.md docs/explanation.md docs/api.md
+	python -m codespell_lib --write README.md docs/tutorial.md docs/how-to-integrate.md docs/how-to-chain-filesystems.md docs/explanation.md docs/api.md
 
 lint: lint-py lint-docs  ## run all linters
 lints: lint

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ ownership of database discovery or dataframe query planning. A pure-Rust core an
 bindings apply the same decisions to Arrow record batches and PyArrow objects.
 
 The first release supports format-aware conversion plans, exact/projection/compatible/
-coerce schema policies, registered Arrow IPC/Parquet/CSV/JSONL codecs, and bounded lazy
-batch iteration with cancellation.
+coerce schema policies, registered Arrow IPC/Parquet/CSV/JSONL codecs, bounded lazy batch
+iteration with cancellation, and read-only conversion through chained fsspec URLs.
 
 ## Documentation
 
@@ -21,6 +21,8 @@ batch iteration with cancellation.
   guided first example.
 - [Connect a batch producer or consumer](https://github.com/1kbgz/fsspec-data/blob/main/docs/how-to-integrate.md)
   to the interchange layer.
+- [Convert a file through an fsspec chain](https://github.com/1kbgz/fsspec-data/blob/main/docs/how-to-chain-filesystems.md)
+  while retaining its source filesystem.
 - [Understand the interchange design](https://github.com/1kbgz/fsspec-data/blob/main/docs/explanation.md)
   and package boundaries.
 - [Look up the interchange API](https://github.com/1kbgz/fsspec-data/blob/main/docs/api.md),

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,5 +1,43 @@
 # Interchange API reference
 
+## `DataFileSystem`
+
+Read-only chained filesystem registered as the `fsspec-data` protocol. The outer path names
+the requested representation; `fo` names the source object on the target filesystem.
+
+Constructor parameters:
+
+- `fo: str`: source object path or URL.
+- `target_protocol: str | None`: protocol used to construct the target filesystem.
+- `target_options: dict | None`: options passed to the target filesystem.
+- `fs: AbstractFileSystem | None`: existing target filesystem. Mutually exclusive with
+  `target_protocol`.
+- `provided_format: DataFormat | str | None`: source format. Inferred from `fo` when omitted.
+- `requested_format: DataFormat | str | None`: output format. Inferred from the opened path
+  when omitted.
+- `provided_schema`: source `pyarrow.Schema` or nested schema options. Required for CSV and
+  JSONL.
+- `requested_schema`: output `pyarrow.Schema` or nested schema options. Defaults to the source
+  schema.
+- `schema_policy: SchemaPolicy | str`: reconciliation policy. Defaults to `exact`.
+- `batch_size: int`: maximum rows per decoded batch. Defaults to `1024`.
+- `row_limit: int | None`: maximum decoded rows.
+- `byte_limit: int | None`: maximum cumulative Arrow array memory in decoded batches.
+- `spool_max_size: int`: converted bytes retained in memory before the seekable output rolls
+  over to a temporary file. Defaults to 8 MiB.
+
+Nested schema options have a `fields` list. Each field has `name`, `type`, and optional
+`nullable` keys. String types use PyArrow aliases such as `int64`, `string`, and
+`timestamp[ms]`.
+
+Recognized suffixes are `.arrow` and `.ipc` for Arrow IPC streams, `.parquet` and `.pq` for
+Parquet, `.csv` for CSV, and `.jsonl` and `.ndjson` for line-delimited JSON.
+
+`open` accepts read mode and returns a seekable spooled file. Conversion currently reads the
+complete encoded source and produces a complete encoded output before returning the file.
+
+See [How to convert a file through an fsspec chain](how-to-chain-filesystems.md) for usage.
+
 ## `DataFormat`
 
 Identifies an interchange encoding. Values are `arrow`, `parquet`, `csv`, and `jsonl`.

--- a/docs/how-to-chain-filesystems.md
+++ b/docs/how-to-chain-filesystems.md
@@ -1,0 +1,62 @@
+# How to convert a file through an fsspec chain
+
+This guide shows you how to expose a source file in another tabular format and Arrow schema
+without replacing its filesystem.
+
+## Define schemas for text input
+
+CSV and JSONL sources require an Arrow schema. Use nested dictionaries when the same options
+must cross the `fsspec-rs` Python bridge:
+
+```python
+schema = {
+    "fields": [
+        {"name": "id", "type": "int64", "nullable": False},
+        {"name": "name", "type": "string", "nullable": True},
+    ]
+}
+```
+
+Pass a `pyarrow.Schema` instead when the chain remains in Python. Arrow IPC and Parquet
+sources provide their own schemas, so `provided_schema` is optional for those formats.
+
+## Open the converted representation
+
+Place the requested representation on the left and the source object on the right:
+
+```python
+import fsspec
+import pyarrow.parquet as pq
+
+url = "fsspec-data://orders.parquet::memory://orders.csv"
+
+with fsspec.open(url, provided_schema=schema) as file:
+    orders = pq.read_table(file)
+```
+
+The outer filename selects Parquet output. The inner filename selects CSV input. Use
+`provided_format` or `requested_format` when a filename has no recognized suffix.
+
+To project, reorder, or cast fields, pass `requested_schema` and the corresponding
+`schema_policy`:
+
+```python
+with fsspec.open(
+    url,
+    provided_schema=schema,
+    requested_schema={"fields": [{"name": "name", "type": "string"}]},
+    schema_policy="projection",
+) as file:
+    names = pq.read_table(file)
+```
+
+For a database source, pass connection settings to the inner protocol:
+
+```python
+url = "fsspec-data://orders.parquet::db+duckdb:///main/orders.arrow"
+
+with fsspec.open(url, **{"db+duckdb": {"database": "warehouse.duckdb"}}) as file:
+    orders = pq.read_table(file)
+```
+
+See the [API reference](api.md#datafilesystem) for constructor options and supported suffixes.

--- a/fsspec_data/__init__.py
+++ b/fsspec_data/__init__.py
@@ -1,3 +1,4 @@
+from .filesystem import DataFileSystem
 from .interchange import (
     DEFAULT_REGISTRY,
     Codec,
@@ -22,6 +23,7 @@ __all__ = [
     "CodecRegistry",
     "DEFAULT_REGISTRY",
     "DataFormat",
+    "DataFileSystem",
     "DecodedBatchStream",
     "DecodedBatches",
     "FieldMapping",

--- a/fsspec_data/filesystem.py
+++ b/fsspec_data/filesystem.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import tempfile
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+import pyarrow as pa
+from fsspec import AbstractFileSystem, filesystem
+from fsspec.core import url_to_fs
+from fsspec.implementations.chained import ChainedFileSystem
+
+from .interchange import DEFAULT_REGISTRY, DataFormat, InterchangeRequest, SchemaPolicy
+
+
+class DataFileSystem(ChainedFileSystem):
+    """Read-only format and schema conversion layered over another filesystem."""
+
+    protocol = "fsspec-data"
+
+    def __init__(
+        self,
+        fo: str,
+        target_protocol: str | None = None,
+        target_options: dict[str, Any] | None = None,
+        fs: AbstractFileSystem | None = None,
+        provided_format: DataFormat | str | None = None,
+        requested_format: DataFormat | str | None = None,
+        provided_schema: pa.Schema | Mapping[str, Any] | Sequence[Mapping[str, Any]] | None = None,
+        requested_schema: pa.Schema | Mapping[str, Any] | Sequence[Mapping[str, Any]] | None = None,
+        schema_policy: SchemaPolicy | str = SchemaPolicy.EXACT,
+        batch_size: int = 1024,
+        row_limit: int | None = None,
+        byte_limit: int | None = None,
+        spool_max_size: int = 8 * 1024 * 1024,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        if fs is not None and target_protocol is not None:
+            raise ValueError("provide either fs or target_protocol, not both")
+        if fs is None:
+            if target_protocol is None:
+                fs, fo = url_to_fs(fo, **(target_options or {}))
+            else:
+                fs = filesystem(target_protocol, **(target_options or {}))
+
+        self.fs = fs
+        self.fo = fs._strip_protocol(fo)
+        self.provided_format = DataFormat(provided_format) if provided_format is not None else None
+        self.requested_format = DataFormat(requested_format) if requested_format is not None else None
+        self.provided_schema = _schema_from_options(provided_schema)
+        self.requested_schema = _schema_from_options(requested_schema)
+        self.schema_policy = SchemaPolicy(schema_policy)
+        self.batch_size = batch_size
+        self.row_limit = row_limit
+        self.byte_limit = byte_limit
+        self.spool_max_size = spool_max_size
+        self._sizes: dict[str, int] = {}
+
+    def _open(
+        self,
+        path: str,
+        mode: str = "rb",
+        block_size: int | None = None,
+        autocommit: bool = True,
+        cache_options: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ):
+        del block_size, autocommit, cache_options, kwargs
+        if mode != "rb":
+            raise ValueError("fsspec-data is a read-only filesystem")
+
+        path = self._strip_protocol(path)
+        output = self._convert(path)
+        file = tempfile.SpooledTemporaryFile(max_size=self.spool_max_size, mode="w+b")
+        file.write(output)
+        file.seek(0)
+        self._sizes[path] = len(output)
+        return file
+
+    def info(self, path: str, **kwargs: Any) -> dict[str, Any]:
+        del kwargs
+        path = self._strip_protocol(path)
+        size = self._sizes.get(path)
+        if size is None:
+            with self._open(path) as file:
+                file.seek(0, 2)
+                size = file.tell()
+        return {"name": path, "size": size, "type": "file"}
+
+    def ls(self, path: str, detail: bool = True, **kwargs: Any):
+        path = self._strip_protocol(path)
+        if not path:
+            return []
+        entry = self.info(path, **kwargs)
+        return [entry] if detail else [entry["name"]]
+
+    def _convert(self, path: str) -> bytes:
+        provided_format = self.provided_format or _format_from_path(self.fo)
+        requested_format = self.requested_format or _format_from_path(path)
+        source = self.fs.cat_file(self.fo)
+        decoded = DEFAULT_REGISTRY.get(provided_format).decode_batches(
+            source,
+            schema=self.provided_schema,
+            batch_size=self.batch_size,
+            row_limit=self.row_limit,
+            byte_limit=self.byte_limit,
+        )
+        if self.provided_schema is not None and not decoded.schema.equals(self.provided_schema, check_metadata=False):
+            raise ValueError("provided schema does not match the source schema")
+
+        provided_schema = self.provided_schema or decoded.schema
+        requested_schema = self.requested_schema or provided_schema
+        plan = InterchangeRequest(
+            provided_format,
+            requested_format,
+            provided_schema,
+            requested_schema,
+            self.schema_policy,
+        ).plan()
+        batches = tuple(plan.apply_batch(batch) for batch in decoded.batches)
+        return DEFAULT_REGISTRY.get(requested_format).encode_batches(batches, schema=requested_schema)
+
+
+_SUFFIX_FORMATS = {
+    ".arrow": DataFormat.ARROW,
+    ".csv": DataFormat.CSV,
+    ".ipc": DataFormat.ARROW,
+    ".jsonl": DataFormat.JSONL,
+    ".ndjson": DataFormat.JSONL,
+    ".parquet": DataFormat.PARQUET,
+    ".pq": DataFormat.PARQUET,
+}
+
+
+def _format_from_path(path: str) -> DataFormat:
+    suffix = "." + path.rsplit(".", 1)[-1].lower() if "." in path.rsplit("/", 1)[-1] else ""
+    try:
+        return _SUFFIX_FORMATS[suffix]
+    except KeyError as error:
+        raise ValueError(f"cannot infer tabular format from path {path!r}") from error
+
+
+def _schema_from_options(
+    value: pa.Schema | Mapping[str, Any] | Sequence[Mapping[str, Any]] | None,
+) -> pa.Schema | None:
+    if value is None or isinstance(value, pa.Schema):
+        return value
+    fields = value.get("fields") if isinstance(value, Mapping) else value
+    if not isinstance(fields, Sequence) or isinstance(fields, (str, bytes)):
+        raise TypeError("schema options must contain a sequence of fields")
+    return pa.schema([_field_from_options(field) for field in fields])
+
+
+def _field_from_options(value: Mapping[str, Any]) -> pa.Field:
+    if not isinstance(value, Mapping):
+        raise TypeError("schema fields must be mappings")
+    try:
+        name = value["name"]
+        data_type = value["type"]
+    except KeyError as error:
+        raise ValueError(f"schema field is missing {error.args[0]!r}") from error
+    if not isinstance(name, str) or not isinstance(data_type, (str, pa.DataType)):
+        raise TypeError("schema field name and type must be strings or PyArrow data types")
+    if isinstance(data_type, str):
+        data_type = pa.type_for_alias(data_type)
+    nullable = value.get("nullable", True)
+    if not isinstance(nullable, bool):
+        raise TypeError("schema field nullable must be a boolean")
+    return pa.field(name, data_type, nullable=nullable)

--- a/fsspec_data/tests/test_filesystem.py
+++ b/fsspec_data/tests/test_filesystem.py
@@ -57,6 +57,11 @@ def test_source_url_constructs_target_filesystem(memory_fs):
     ]
 
 
+def test_target_filesystem_arguments_are_mutually_exclusive(memory_fs):
+    with pytest.raises(ValueError, match="either fs or target_protocol"):
+        DataFileSystem(fo="orders.csv", fs=memory_fs, target_protocol="memory", provided_schema=SCHEMA)
+
+
 def test_embedded_schema_can_be_projected(memory_fs):
     parquet = pa.BufferOutputStream()
     pq.write_table(pa.table({"id": [1, 2], "name": ["ada", "grace"]}), parquet)
@@ -92,6 +97,19 @@ def test_converted_output_rolls_over_at_spool_limit(memory_fs):
         assert file.read(4) == b"PAR1"
 
 
+def test_info_and_listing_describe_converted_path(memory_fs):
+    fs = DataFileSystem(fo="orders.csv", fs=memory_fs, provided_schema=SCHEMA)
+
+    info = fs.info("orders.parquet")
+
+    assert info == {"name": "orders.parquet", "size": info["size"], "type": "file"}
+    assert info["size"] > 4
+    assert fs.info("orders.parquet") == info
+    assert fs.ls("orders.parquet") == [info]
+    assert fs.ls("orders.parquet", detail=False) == ["orders.parquet"]
+    assert fs.ls("") == []
+
+
 def test_filesystem_is_read_only(memory_fs):
     fs = DataFileSystem(fo="orders.csv", fs=memory_fs, provided_schema=SCHEMA)
 
@@ -111,3 +129,43 @@ def test_unknown_extension_requires_explicit_format(memory_fs):
 
     with pytest.raises(ValueError, match="cannot infer tabular format"):
         fs.open("orders.bin")
+
+
+def test_extensionless_path_requires_explicit_format(memory_fs):
+    fs = DataFileSystem(fo="orders.csv", fs=memory_fs, provided_schema=SCHEMA)
+
+    with pytest.raises(ValueError, match="cannot infer tabular format"):
+        fs.open("orders")
+
+
+def test_schema_options_accept_a_field_sequence(memory_fs):
+    fs = DataFileSystem(
+        fo="orders.csv",
+        fs=memory_fs,
+        provided_schema=[
+            {"name": "id", "type": pa.int64(), "nullable": False},
+            {"name": "name", "type": "string"},
+        ],
+    )
+
+    assert pq.read_table(fs.open("orders.parquet")).to_pylist() == [
+        {"id": 1, "name": "ada"},
+        {"id": 2, "name": "grace"},
+    ]
+
+
+@pytest.mark.parametrize(
+    ("schema", "error", "message"),
+    [
+        ({"fields": "invalid"}, TypeError, "sequence of fields"),
+        ({"fields": ["invalid"]}, TypeError, "fields must be mappings"),
+        ({"fields": [{}]}, ValueError, "missing 'name'"),
+        ({"fields": [{"name": "id"}]}, ValueError, "missing 'type'"),
+        ({"fields": [{"name": 1, "type": "int64"}]}, TypeError, "name and type"),
+        ({"fields": [{"name": "id", "type": object()}]}, TypeError, "name and type"),
+        ({"fields": [{"name": "id", "type": "int64", "nullable": "yes"}]}, TypeError, "nullable must be a boolean"),
+    ],
+)
+def test_invalid_schema_options_are_rejected(memory_fs, schema, error, message):
+    with pytest.raises(error, match=message):
+        DataFileSystem(fo="orders.csv", fs=memory_fs, provided_schema=schema)

--- a/fsspec_data/tests/test_filesystem.py
+++ b/fsspec_data/tests/test_filesystem.py
@@ -1,0 +1,113 @@
+import fsspec
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from fsspec_data import DataFileSystem
+
+SCHEMA = pa.schema([pa.field("id", pa.int64(), nullable=False), pa.field("name", pa.string())])
+SCHEMA_OPTIONS = {
+    "fields": [
+        {"name": "id", "type": "int64", "nullable": False},
+        {"name": "name", "type": "string", "nullable": True},
+    ]
+}
+
+
+@pytest.fixture
+def memory_fs():
+    fs = fsspec.filesystem("memory")
+    fs.store.clear()
+    fs.pipe("orders.csv", b"id,name\n1,ada\n2,grace\n")
+    return fs
+
+
+def test_chained_filesystem_converts_csv_to_seekable_parquet(memory_fs):
+    fs = DataFileSystem(fo="orders.csv", fs=memory_fs, provided_schema=SCHEMA_OPTIONS)
+
+    with fs.open("orders.parquet", "rb") as file:
+        assert file.read(4) == b"PAR1"
+        file.seek(0)
+        table = pq.read_table(file)
+
+    assert table.schema.equals(SCHEMA, check_metadata=False)
+    assert table.to_pylist() == [{"id": 1, "name": "ada"}, {"id": 2, "name": "grace"}]
+
+
+def test_fsspec_url_builds_chained_filesystem(memory_fs):
+    fsspec.register_implementation("fsspec-data", DataFileSystem, clobber=True)
+
+    fs, path = fsspec.core.url_to_fs(
+        "fsspec-data://orders.parquet::memory://orders.csv",
+        provided_schema=SCHEMA_OPTIONS,
+    )
+
+    assert isinstance(fs, DataFileSystem)
+    assert path == "orders.parquet"
+    assert fs.fo == "/orders.csv"
+    assert pq.read_table(fs.open(path)).to_pylist() == [{"id": 1, "name": "ada"}, {"id": 2, "name": "grace"}]
+
+
+def test_source_url_constructs_target_filesystem(memory_fs):
+    fs = DataFileSystem(fo="memory://orders.csv", provided_schema=SCHEMA_OPTIONS)
+
+    assert pq.read_table(fs.open("orders.parquet")).to_pylist() == [
+        {"id": 1, "name": "ada"},
+        {"id": 2, "name": "grace"},
+    ]
+
+
+def test_embedded_schema_can_be_projected(memory_fs):
+    parquet = pa.BufferOutputStream()
+    pq.write_table(pa.table({"id": [1, 2], "name": ["ada", "grace"]}), parquet)
+    memory_fs.pipe("orders.parquet", parquet.getvalue().to_pybytes())
+    fs = DataFileSystem(
+        fo="orders.parquet",
+        fs=memory_fs,
+        requested_schema={"fields": [{"name": "name", "type": "string"}]},
+        schema_policy="projection",
+    )
+
+    with fs.open("orders.arrow") as file:
+        result = pa.ipc.open_stream(file).read_all()
+
+    assert result.to_pylist() == [{"name": "ada"}, {"name": "grace"}]
+
+
+def test_embedded_schema_is_asserted(memory_fs):
+    parquet = pa.BufferOutputStream()
+    pq.write_table(pa.table({"id": [1]}), parquet)
+    memory_fs.pipe("orders.parquet", parquet.getvalue().to_pybytes())
+    fs = DataFileSystem(fo="orders.parquet", fs=memory_fs, provided_schema=pa.schema([("id", pa.int32())]))
+
+    with pytest.raises(ValueError, match="provided schema does not match"):
+        fs.open("orders.arrow")
+
+
+def test_converted_output_rolls_over_at_spool_limit(memory_fs):
+    fs = DataFileSystem(fo="orders.csv", fs=memory_fs, provided_schema=SCHEMA, spool_max_size=1)
+
+    with fs.open("orders.parquet") as file:
+        assert file._rolled
+        assert file.read(4) == b"PAR1"
+
+
+def test_filesystem_is_read_only(memory_fs):
+    fs = DataFileSystem(fo="orders.csv", fs=memory_fs, provided_schema=SCHEMA)
+
+    with pytest.raises(ValueError, match="read-only"):
+        fs.open("orders.parquet", "wb")
+
+
+def test_text_input_requires_schema(memory_fs):
+    fs = DataFileSystem(fo="orders.csv", fs=memory_fs)
+
+    with pytest.raises(ValueError, match="requires an Arrow schema"):
+        fs.open("orders.parquet")
+
+
+def test_unknown_extension_requires_explicit_format(memory_fs):
+    fs = DataFileSystem(fo="orders.csv", fs=memory_fs, provided_schema=SCHEMA)
+
+    with pytest.raises(ValueError, match="cannot infer tabular format"):
+        fs.open("orders.bin")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,9 @@ develop = [
 
 [project.scripts]
 
+[project.entry-points."fsspec.specs"]
+"fsspec-data" = "fsspec_data.filesystem:DataFileSystem"
+
 [project.urls]
 Repository = "https://github.com/1kbgz/fsspec-data"
 Homepage = "https://github.com/1kbgz/fsspec-data"
@@ -100,6 +103,9 @@ exclude_also = [
 ]
 ignore_errors = true
 fail_under = 10
+
+[tool.codespell]
+ignore-words-list = "fo"
 
 [tool.hatch.build]
 artifacts = [
@@ -173,5 +179,11 @@ section-order = [
 [tool.yardang]
 title = "fsspec-data"
 root = "README.md"
-pages = ["docs/tutorial.md", "docs/how-to-integrate.md", "docs/explanation.md", "docs/api.md"]
+pages = [
+    "docs/tutorial.md",
+    "docs/how-to-integrate.md",
+    "docs/how-to-chain-filesystems.md",
+    "docs/explanation.md",
+    "docs/api.md",
+]
 use-autoapi = true


### PR DESCRIPTION
- register a read-only fsspec-data chained filesystem
- convert formats and assert or reconcile Arrow schemas through the shared interchange core
- provide seekable spooling, nested bridge-safe schema options, tests, and public documentation
