### PR TITLE
Build wheels on macOS and Windows

### DIFF
--- a/.copier-answers.yaml
+++ b/.copier-answers.yaml
@@ -2,7 +2,7 @@
 _commit: '4875149'
 _src_path: https://github.com/python-project-templates/base.git
 add_docs: true
-add_extension: python
+add_extension: rust
 add_wiki: false
 email: t.paine154@gmail.com
 github: 1kbgz

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,7 +29,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.11"]
 
     steps:
@@ -39,6 +39,8 @@ jobs:
       with:
         version: ${{ matrix.python-version }}
 
+    - uses: actions-ext/rust/setup@main
+
     - name: Install dependencies
       run: make develop
 
@@ -47,6 +49,7 @@ jobs:
 
     - name: Checks
       run: make checks
+      if: matrix.os == 'ubuntu-latest'
 
     - name: Build
       run: make build
@@ -58,29 +61,55 @@ jobs:
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: test-results-${{ matrix.os }}-${{ matrix.python-version }}
-        path: junit.xml
+        path: '**/junit.xml'
       if: ${{ always() }}
 
     - name: Publish Unit Test Results
       uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2.24.0
       with:
         files: '**/junit.xml'
+      if: matrix.os == 'ubuntu-latest'
 
     - name: Upload coverage
       uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
 
-    - name: Make dist
-      run: make dist
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+      with:
+        platforms: all
+      if: runner.os == 'Linux' && runner.arch == 'X64'
+
+    - name: Make dist (Linux)
+      run: |
+        rm -rf dist
+        make dist-rs
+        make dist-py-sdist
+        make dist-py-wheel
+        make dist-check
+      shell: bash
+      if: matrix.os == 'ubuntu-latest'
+
+    - name: Make dist (Macos / Windows)
+      run: |
+        rm -rf dist
+        make dist-py-wheel
+        make dist-check
+      shell: bash
+      env:
+        CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=11.0
+      if: matrix.os != 'ubuntu-latest'
 
     - uses: actions-ext/python/test-wheel@main
       with:
         module: fsspec_data
+      if: matrix.os == 'ubuntu-latest'
 
     - uses: actions-ext/python/test-sdist@main
       with:
         module: fsspec_data
+      if: matrix.os == 'ubuntu-latest'
 
     - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:

--- a/Makefile
+++ b/Makefile
@@ -1,51 +1,74 @@
 #########
 # BUILD #
 #########
-.PHONY: develop build install
-
-develop:  ## install dependencies and build library
+.PHONY: develop-py develop-rs develop
+develop-py:
 	uv pip install -e .[develop]
 
-rust-test:  ## test the pure Rust interchange core
-	cargo test --workspace
+develop-rs:
+	make -C rust develop
 
-requirements:  ## install prerequisite python build requirements
+develop: develop-rs develop-py  ## setup project for development
+
+.PHONY: requirements-py requirements-rs requirements
+requirements-py:  ## install prerequisite python build requirements
 	python -m pip install --upgrade pip toml
 	python -m pip install `python -c 'import toml; c = toml.load("pyproject.toml"); print("\n".join(c["build-system"]["requires"]))'`
 	python -m pip install `python -c 'import toml; c = toml.load("pyproject.toml"); print(" ".join(c["project"]["optional-dependencies"]["develop"]))'`
 
-build:  ## build the python library
-	python -m build -n
+requirements-rs:  ## install prerequisite rust build requirements
+	make -C rust requirements
 
-install:  ## install library
+requirements: requirements-rs requirements-py  ## setup project for development
+
+.PHONY: build-py build-rs build
+build-py:
+	python -m build -w -n
+
+build-rs:
+	make -C rust build
+
+build: build-rs build-py  ## build the project
+
+.PHONY: install
+install:  ## install python library
 	uv pip install .
 
 #########
 # LINTS #
 #########
-.PHONY: lint-py lint-docs fix-py fix-docs lint lints fix format
-
-lint-py:  ## lint python with ruff
+.PHONY: lint-py lint-rs lint-docs lint lints
+lint-py:  ## run python linter with ruff
 	python -m ruff check fsspec_data
 	python -m ruff format --check fsspec_data
-	cargo fmt --all -- --check
-	cargo clippy --workspace --all-targets -- -D warnings
+
+lint-rs:  ## run rust linter
+	make -C rust lint
 
 lint-docs:  ## lint docs with mdformat and codespell
 	python -m mdformat --check README.md docs/tutorial.md docs/how-to-integrate.md docs/how-to-chain-filesystems.md docs/explanation.md docs/api.md
 	python -m codespell_lib README.md docs/tutorial.md docs/how-to-integrate.md docs/how-to-chain-filesystems.md docs/explanation.md docs/api.md
 
-fix-py:  ## autoformat python code with ruff
+lint: lint-rs lint-py lint-docs  ## run project linters
+
+# alias
+lints: lint
+
+.PHONY: fix-py fix-rs fix-docs fix format
+fix-py:  ## fix python formatting with ruff
 	python -m ruff check --fix fsspec_data
 	python -m ruff format fsspec_data
+
+fix-rs:  ## fix code with rustfmt
+	make -C rust fix
 
 fix-docs:  ## autoformat docs with mdformat and codespell
 	python -m mdformat README.md docs/tutorial.md docs/how-to-integrate.md docs/how-to-chain-filesystems.md docs/explanation.md docs/api.md
 	python -m codespell_lib --write README.md docs/tutorial.md docs/how-to-integrate.md docs/how-to-chain-filesystems.md docs/explanation.md docs/api.md
 
-lint: lint-py lint-docs  ## run all linters
-lints: lint
-fix: fix-py fix-docs  ## run all autoformatters
+fix: fix-rs fix-py fix-docs  ## run project autoformatters
+
+# alias
 format: fix
 
 ################
@@ -61,21 +84,37 @@ check-types:  ## check python types with ty
 
 checks: check-dist
 
-# Alias
+# alias
 check: checks
 
 #########
 # TESTS #
 #########
-.PHONY: test coverage tests
-
-test: rust-test  ## run Rust and Python tests
+.PHONY: test-py tests-py coverage-py
+test-py:  ## run python tests
 	python -m pytest -v fsspec_data/tests
 
-coverage: rust-test  ## run tests and collect test coverage
+# alias
+tests-py: test-py
+
+coverage-py:  ## run python tests and collect test coverage
 	python -m pytest -v fsspec_data/tests --cov=fsspec_data --cov-report term-missing --cov-report xml
 
-# Alias
+.PHONY: test-rs tests-rs coverage-rs
+test-rs:  ## run rust tests
+	make -C rust test
+
+# alias
+tests-rs: test-rs
+
+coverage-rs:  ## run Rust tests and collect coverage
+	make -C rust coverage
+
+.PHONY: test coverage tests
+test: test-py test-rs  ## run all tests
+coverage: coverage-py coverage-rs  ## run all tests and collect test coverage
+
+# alias
 tests: test
 
 ###########
@@ -98,15 +137,21 @@ major:  ## bump a major version
 ########
 # DIST #
 ########
-.PHONY: dist dist-build dist-sdist dist-local-wheel publish
+.PHONY: dist-py-wheel dist-py-sdist dist-rs dist-check dist publish
 
-dist-build:  # build python dists
-	python -m build -w -s
+dist-py-wheel:  ## build python wheels
+	python -m cibuildwheel --output-dir dist
 
-dist-check:  ## run python dist checker with twine
+dist-py-sdist:  ## build Python sdist
+	python -m build --sdist -o dist
+
+dist-rs:  ## validate Rust crate distribution
+	make -C rust dist
+
+dist-check:  ## run Python dist checker with twine
 	python -m twine check dist/*
 
-dist: clean dist-build dist-check  ## build all dists
+dist: clean build dist-rs dist-py-wheel dist-py-sdist dist-check  ## build all dists
 
 publish: dist  ## publish python assets
 
@@ -115,10 +160,10 @@ publish: dist  ## publish python assets
 #########
 .PHONY: deep-clean clean
 
-deep-clean: ## clean everything from the repository
+deep-clean: ## clean everything in the repository
 	git clean -fdx
 
-clean: ## clean the repository
+clean: ## clean generated build artifacts
 	rm -rf .coverage coverage cover htmlcov logs build dist *.egg-info
 
 ############################################################################################

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ develop = [
     "build",
     "bump-my-version",
     "check-dist",
+    "cibuildwheel",
     "codespell",
     "hatchling",
     "hatch-rs",
@@ -89,6 +90,29 @@ filename = "rust/Cargo.toml"
 search = 'version = "{current_version}"'
 replace = 'version = "{new_version}"'
 
+[tool.cibuildwheel]
+build = "cp311-*"
+test-command = "pytest -vvv {project}/fsspec_data/tests"
+test-extras = "develop"
+
+[tool.cibuildwheel.linux]
+before-all = """
+curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain=stable --profile=minimal -y
+rustup target add aarch64-unknown-linux-gnu
+rustup target add x86_64-unknown-linux-gnu
+rustup show
+"""
+environment = {PATH="$HOME/.cargo/bin:$PATH", CARGO_TERM_COLOR="always"}
+skip = "*i686* *musllinux*"
+
+[tool.cibuildwheel.macos]
+environment = {PATH="$HOME/.cargo/bin:$PATH", CARGO_TERM_COLOR="always", MACOS_DEPLOYMENT_TARGET=11.0}
+archs = "arm64"
+
+[tool.cibuildwheel.windows]
+environment = {PATH="$UserProfile\\.cargo\bin;$PATH", CARGO_TERM_COLOR="always"}
+skip = "*win32 *arm_64"
+
 [tool.coverage.run]
 branch = true
 omit = [
@@ -131,6 +155,7 @@ packages = [
     "Cargo.lock",
 ]
 exclude = [
+    "rust/Makefile",
     "target",
 ]
 
@@ -138,8 +163,9 @@ exclude = [
 packages = [
     "fsspec_data",
 ]
-
-[tool.hatch.build.targets.wheel.shared-data]
+exclude = [
+    "rust",
+]
 
 [tool.pytest.ini_options]
 addopts = [

--- a/rust/.config/nextest.toml
+++ b/rust/.config/nextest.toml
@@ -1,0 +1,2 @@
+[profile.default.junit]
+path = "junit.xml"

--- a/rust/Makefile
+++ b/rust/Makefile
@@ -1,0 +1,57 @@
+.PHONY: requirements develop build
+requirements:  ## install required dev dependencies
+	rustup component add rustfmt
+	rustup component add clippy
+	cargo install --locked --force cargo-nextest
+	cargo install --force cargo-llvm-cov
+
+develop: requirements  ## install required dev dependencies
+
+build:  ## build release
+	cargo build --release --all-features --package fsspec_data
+
+.PHONY: lint lints fix format
+lint:  ## run Clippy for linting, rustfmt for autoformat checks
+	cargo clippy --workspace --all-targets --all-features -- -D warnings
+	cargo fmt --all -- --check
+
+# alias
+lints: lint
+
+fix:  ## fix code with rustfmt
+	cargo fmt --all
+
+# alias
+format: fix
+
+.PHONY: check checks
+check:
+	cargo check --workspace --all-features
+
+# alias
+checks: check
+
+.PHONY: test tests
+test:  ## run the tests
+	cargo llvm-cov nextest --workspace --cobertura --output-path junit.xml
+
+# alias
+tests: test
+
+coverage:  ## collect Rust test coverage
+	cargo llvm-cov nextest --workspace --lcov --output-path coverage
+
+.PHONY: dist publish
+dist:  ## validate crate packaging
+	cargo publish --workspace --dry-run --allow-dirty
+
+publish:  ## publish crates
+	cargo publish --workspace
+
+# Thanks to Francoise at marmelab.com for this
+.DEFAULT_GOAL := help
+help:
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+print-%:
+	@echo '$*=$($*)'


### PR DESCRIPTION
- select the Rust Copier template variant
- add cibuildwheel configuration and Rust build tooling
- build and upload Linux, macOS, and Windows wheel artifacts
- retain Linux-only sdist and Rust crate validation
