### PR TITLE
Add resumable codec writers

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -146,6 +146,25 @@ Parameters:
 Calls `iter_batches(...)`, consumes the stream, and returns `DecodedBatches`. Parameters and
 errors match `iter_batches`.
 
+## Rust `CodecWriter`
+
+A resumable encoded-output session returned by `Codec::start_writer`.
+
+Methods:
+
+- `write_batch(&mut self, batch: &RecordBatch)`: validates the batch against the session
+  schema and submits it to the format writer.
+- `finish(self: Box<Self>)`: writes the format footer and consumes the session. The borrowed
+  sink remains owned by the caller.
+
+Arrow IPC and Parquet codecs support resumable writers. CSV and JSONL return
+`InterchangeError::CodecWriterNotSupported`.
+
+Arrow IPC makes encoded batch bytes available to the sink during `write_batch`. The Parquet
+writer accepts batches incrementally but may buffer its output until `finish`.
+
+`Codec::encode_stream` uses the same writer session for Arrow IPC and Parquet.
+
 ## `CodecRegistry`
 
 ### `get(format)`

--- a/docs/how-to-integrate.md
+++ b/docs/how-to-integrate.md
@@ -68,7 +68,16 @@ let decoded = source.decode_stream(
 )?;
 let mut batches = plan.apply_stream(decoded);
 let mut output = Vec::new();
-target.encode_stream(target_schema, &mut batches, &mut output)?;
+let mut writer = target.start_writer(target_schema, &mut output)?;
+for batch in batches {
+    writer.write_batch(&batch?)?;
+}
+writer.finish()?;
 ```
+
+Use `start_writer` for Arrow IPC or Parquet when the producer supplies batches over time.
+Arrow IPC emits bytes during batch writes. Parquet accepts batches incrementally but may
+buffer encoded bytes until `finish`. Use `encode_stream` when the complete iterator can be
+consumed by one call.
 
 See the [API reference](api.md) for supported formats, limits, casts, and errors.

--- a/rust/python/lib.rs
+++ b/rust/python/lib.rs
@@ -145,7 +145,9 @@ fn plan_schema(
 
 fn to_python_error(error: InterchangeError) -> PyErr {
     match error {
-        InterchangeError::UnsupportedPolicy(_) | InterchangeError::CodecNotRegistered(_) => {
+        InterchangeError::UnsupportedPolicy(_)
+        | InterchangeError::CodecNotRegistered(_)
+        | InterchangeError::CodecWriterNotSupported(_) => {
             pyo3::exceptions::PyNotImplementedError::new_err(error.to_string())
         }
         InterchangeError::StreamCancelled => {

--- a/rust/src/codec.rs
+++ b/rust/src/codec.rs
@@ -28,6 +28,11 @@ pub struct DecodedBatches {
     pub batches: Vec<RecordBatch>,
 }
 
+pub trait CodecWriter: Send {
+    fn write_batch(&mut self, batch: &RecordBatch) -> Result<()>;
+    fn finish(self: Box<Self>) -> Result<()>;
+}
+
 pub trait Codec: Send + Sync {
     fn format(&self) -> DataFormat;
     fn capabilities(&self) -> CodecCapabilities;
@@ -44,6 +49,16 @@ pub trait Codec: Send + Sync {
         options: StreamOptions,
         cancellation: CancellationToken,
     ) -> Result<DecodedStream>;
+
+    fn start_writer<'a>(
+        &self,
+        _schema: SchemaRef,
+        _output: &'a mut (dyn Write + Send),
+    ) -> Result<Box<dyn CodecWriter + 'a>> {
+        Err(InterchangeError::CodecWriterNotSupported(
+            self.format().as_str().to_string(),
+        ))
+    }
 
     fn encode(&self, schema: SchemaRef, batches: &[RecordBatch]) -> Result<Vec<u8>> {
         let mut output = Vec::new();
@@ -98,6 +113,25 @@ pub static DEFAULT_REGISTRY: LazyLock<CodecRegistry> = LazyLock::new(|| {
 
 pub struct ArrowIpcCodec;
 
+struct ArrowIpcWriter<'a> {
+    schema: SchemaRef,
+    writer: StreamWriter<&'a mut (dyn Write + Send)>,
+}
+
+impl CodecWriter for ArrowIpcWriter<'_> {
+    fn write_batch(&mut self, batch: &RecordBatch) -> Result<()> {
+        validate_batch(&self.schema, batch)?;
+        self.writer.write(batch)?;
+        self.writer.flush()?;
+        Ok(())
+    }
+
+    fn finish(mut self: Box<Self>) -> Result<()> {
+        self.writer.finish()?;
+        Ok(())
+    }
+}
+
 impl Codec for ArrowIpcCodec {
     fn format(&self) -> DataFormat {
         DataFormat::Arrow
@@ -117,18 +151,11 @@ impl Codec for ArrowIpcCodec {
         batches: &mut dyn Iterator<Item = Result<RecordBatch>>,
         output: &mut (dyn Write + Send),
     ) -> Result<()> {
-        {
-            let mut writer = StreamWriter::try_new(output, schema.as_ref())?;
-            for batch in batches {
-                let batch = batch?;
-                if batch.schema() != schema {
-                    return Err(InterchangeError::InputSchema);
-                }
-                writer.write(&batch)?;
-            }
-            writer.finish()?;
+        let mut writer = self.start_writer(schema, output)?;
+        for batch in batches {
+            writer.write_batch(&batch?)?;
         }
-        Ok(())
+        writer.finish()
     }
 
     fn decode_stream(
@@ -147,9 +174,37 @@ impl Codec for ArrowIpcCodec {
             cancellation,
         )
     }
+
+    fn start_writer<'a>(
+        &self,
+        schema: SchemaRef,
+        output: &'a mut (dyn Write + Send),
+    ) -> Result<Box<dyn CodecWriter + 'a>> {
+        let writer = StreamWriter::try_new(output, schema.as_ref())?;
+        Ok(Box::new(ArrowIpcWriter { schema, writer }))
+    }
 }
 
 pub struct ParquetCodec;
+
+struct ParquetWriter<'a> {
+    schema: SchemaRef,
+    writer: ArrowWriter<&'a mut (dyn Write + Send)>,
+}
+
+impl CodecWriter for ParquetWriter<'_> {
+    fn write_batch(&mut self, batch: &RecordBatch) -> Result<()> {
+        validate_batch(&self.schema, batch)?;
+        self.writer.write(batch)?;
+        self.writer.flush()?;
+        Ok(())
+    }
+
+    fn finish(mut self: Box<Self>) -> Result<()> {
+        self.writer.finish()?;
+        Ok(())
+    }
+}
 
 impl Codec for ParquetCodec {
     fn format(&self) -> DataFormat {
@@ -170,18 +225,11 @@ impl Codec for ParquetCodec {
         batches: &mut dyn Iterator<Item = Result<RecordBatch>>,
         output: &mut (dyn Write + Send),
     ) -> Result<()> {
-        {
-            let mut writer = ArrowWriter::try_new(output, schema.clone(), None)?;
-            for batch in batches {
-                let batch = batch?;
-                if batch.schema() != schema {
-                    return Err(InterchangeError::InputSchema);
-                }
-                writer.write(&batch)?;
-            }
-            writer.close()?;
+        let mut writer = self.start_writer(schema, output)?;
+        for batch in batches {
+            writer.write_batch(&batch?)?;
         }
-        Ok(())
+        writer.finish()
     }
 
     fn decode_stream(
@@ -201,6 +249,15 @@ impl Codec for ParquetCodec {
             options,
             cancellation,
         )
+    }
+
+    fn start_writer<'a>(
+        &self,
+        schema: SchemaRef,
+        output: &'a mut (dyn Write + Send),
+    ) -> Result<Box<dyn CodecWriter + 'a>> {
+        let writer = ArrowWriter::try_new(output, schema.clone(), None)?;
+        Ok(Box::new(ParquetWriter { schema, writer }))
     }
 }
 
@@ -318,12 +375,46 @@ fn required_schema(format: DataFormat, schema: Option<SchemaRef>) -> Result<Sche
     schema.ok_or_else(|| InterchangeError::DecodeSchemaRequired(format.as_str().to_string()))
 }
 
+fn validate_batch(schema: &SchemaRef, batch: &RecordBatch) -> Result<()> {
+    if batch.schema().as_ref() != schema.as_ref() {
+        return Err(InterchangeError::InputSchema);
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
+    use std::io;
+    use std::sync::Mutex;
+
     use arrow::array::{Int64Array, RecordBatch, StringArray};
     use arrow::datatypes::{DataType, Field, Schema};
 
     use super::*;
+
+    #[derive(Clone, Default)]
+    struct SharedSink(Arc<Mutex<Vec<u8>>>);
+
+    impl SharedSink {
+        fn bytes(&self) -> Vec<u8> {
+            self.0.lock().unwrap().clone()
+        }
+
+        fn len(&self) -> usize {
+            self.0.lock().unwrap().len()
+        }
+    }
+
+    impl Write for SharedSink {
+        fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buffer);
+            Ok(buffer.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
 
     fn fixture() -> (SchemaRef, Vec<RecordBatch>) {
         let schema = Arc::new(Schema::new(vec![
@@ -396,6 +487,74 @@ mod tests {
 
         assert_eq!(decoded.schema, schema);
         assert!(decoded.batches.is_empty());
+    }
+
+    #[test]
+    fn resumable_writers_encode_batches_incrementally() {
+        let (schema, batches) = fixture();
+
+        for format in [DataFormat::Arrow, DataFormat::Parquet] {
+            let codec = DEFAULT_REGISTRY.get(format).unwrap();
+            let mut sink = SharedSink::default();
+            let observed = sink.clone();
+            let mut writer = codec.start_writer(schema.clone(), &mut sink).unwrap();
+            let header_len = observed.len();
+            writer.write_batch(&batches[0]).unwrap();
+            let first_len = observed.len();
+            writer.write_batch(&batches[1]).unwrap();
+            let second_len = observed.len();
+            writer.finish().unwrap();
+
+            match format {
+                DataFormat::Arrow => {
+                    assert!(first_len > header_len);
+                    assert!(second_len > first_len);
+                }
+                DataFormat::Parquet => {
+                    assert_eq!(first_len, header_len);
+                    assert_eq!(second_len, first_len);
+                }
+                _ => unreachable!(),
+            }
+            assert!(observed.len() > second_len);
+            let encoded = observed.bytes();
+            let decoded = codec.decode(&encoded, None).unwrap();
+            let combined = arrow::compute::concat_batches(&schema, &decoded.batches).unwrap();
+            let expected = arrow::compute::concat_batches(&schema, &batches).unwrap();
+            assert_eq!(combined, expected);
+        }
+    }
+
+    #[test]
+    fn resumable_writers_reject_mismatched_batches() {
+        let (schema, _) = fixture();
+        let mismatched = RecordBatch::new_empty(Arc::new(Schema::empty()));
+
+        for format in [DataFormat::Arrow, DataFormat::Parquet] {
+            let codec = DEFAULT_REGISTRY.get(format).unwrap();
+            let mut encoded = Vec::new();
+            let mut writer = codec.start_writer(schema.clone(), &mut encoded).unwrap();
+            let error = writer.write_batch(&mismatched).unwrap_err().to_string();
+
+            assert!(error.contains("input schema"));
+        }
+    }
+
+    #[test]
+    fn text_codecs_reject_resumable_writers() {
+        let (schema, _) = fixture();
+
+        for format in [DataFormat::Csv, DataFormat::JsonLines] {
+            let codec = DEFAULT_REGISTRY.get(format).unwrap();
+            let mut encoded = Vec::new();
+            let error = codec
+                .start_writer(schema.clone(), &mut encoded)
+                .err()
+                .unwrap()
+                .to_string();
+
+            assert!(error.contains("does not support resumable encoding"));
+        }
     }
 
     #[test]

--- a/rust/src/error.rs
+++ b/rust/src/error.rs
@@ -6,6 +6,8 @@ pub enum InterchangeError {
     UnknownFormat(String),
     #[error("no codec is registered for format: {0}")]
     CodecNotRegistered(String),
+    #[error("codec does not support resumable encoding: {0}")]
+    CodecWriterNotSupported(String),
     #[error("decoding {0} requires an Arrow schema")]
     DecodeSchemaRequired(String),
     #[error("schema policy is not implemented: {0}")]

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -4,7 +4,7 @@ mod plan;
 mod stream;
 
 pub use codec::{
-    ArrowIpcCodec, Codec, CodecCapabilities, CodecRegistry, CsvCodec, DecodedBatches,
+    ArrowIpcCodec, Codec, CodecCapabilities, CodecRegistry, CodecWriter, CsvCodec, DecodedBatches,
     JsonLinesCodec, ParquetCodec, DEFAULT_REGISTRY,
 };
 pub use error::{InterchangeError, Result};


### PR DESCRIPTION
## Description

Add object-safe resumable writer sessions to the Rust codec registry. Arrow IPC and Parquet writers accept schema-checked record batches one at a time and finish without taking ownership of the caller's sink. Existing encode_stream calls use the same sessions.

Arrow IPC exposes encoded bytes during batch writes. Parquet accepts batches incrementally but may buffer output until finish. CSV and JSONL report explicit unsupported-writer errors.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Documentation update
- [ ] Refactor / code cleanup
- [ ] CI / build configuration
- [ ] Other (describe below)

## Checklist

- [x] Linting passes (make lint)
- [x] Tests pass (25 Rust tests and 51 Python tests)
- [x] New tests added for new functionality
- [x] Documentation updated
- [ ] Changelog / version bump (left for release)