### PR TITLE
Add owned codec writer sessions

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -165,6 +165,17 @@ writer accepts batches incrementally but may buffer its output until `finish`.
 
 `Codec::encode_stream` uses the same writer session for Arrow IPC and Parquet.
 
+### `Codec::start_writer(schema, output)`
+
+Borrows a `Write + Send` sink and returns a writer session with the same lifetime. This form
+supports scoped encoding while preserving direct access to the sink after `finish`.
+
+### `Codec::start_owned_writer(schema, output)`
+
+Takes a boxed `Write + Send` sink and returns a writer session without a borrowed lifetime.
+This form supports storing the writer in a long-lived file or stream object. Shared or
+cloneable sinks allow the caller to observe output while the session owns its sink handle.
+
 ## `CodecRegistry`
 
 ### `get(format)`

--- a/docs/how-to-integrate.md
+++ b/docs/how-to-integrate.md
@@ -80,4 +80,14 @@ Arrow IPC emits bytes during batch writes. Parquet accepts batches incrementally
 buffer encoded bytes until `finish`. Use `encode_stream` when the complete iterator can be
 consumed by one call.
 
+If the writer session must be stored beyond the scope that creates it, pass a boxed shared
+sink to `start_owned_writer`:
+
+```rust
+let sink = SharedSink::default();
+let output = sink.clone();
+let writer = target.start_owned_writer(target_schema, Box::new(sink))?;
+let file = EncodedFile::new(writer, output);
+```
+
 See the [API reference](api.md) for supported formats, limits, casts, and errors.

--- a/rust/src/codec.rs
+++ b/rust/src/codec.rs
@@ -60,6 +60,16 @@ pub trait Codec: Send + Sync {
         ))
     }
 
+    fn start_owned_writer(
+        &self,
+        _schema: SchemaRef,
+        _output: Box<dyn Write + Send>,
+    ) -> Result<Box<dyn CodecWriter>> {
+        Err(InterchangeError::CodecWriterNotSupported(
+            self.format().as_str().to_string(),
+        ))
+    }
+
     fn encode(&self, schema: SchemaRef, batches: &[RecordBatch]) -> Result<Vec<u8>> {
         let mut output = Vec::new();
         let mut batches = batches.iter().cloned().map(Ok);
@@ -113,12 +123,12 @@ pub static DEFAULT_REGISTRY: LazyLock<CodecRegistry> = LazyLock::new(|| {
 
 pub struct ArrowIpcCodec;
 
-struct ArrowIpcWriter<'a> {
+struct ArrowIpcWriter<W: Write + Send> {
     schema: SchemaRef,
-    writer: StreamWriter<&'a mut (dyn Write + Send)>,
+    writer: StreamWriter<W>,
 }
 
-impl CodecWriter for ArrowIpcWriter<'_> {
+impl<W: Write + Send> CodecWriter for ArrowIpcWriter<W> {
     fn write_batch(&mut self, batch: &RecordBatch) -> Result<()> {
         validate_batch(&self.schema, batch)?;
         self.writer.write(batch)?;
@@ -183,16 +193,25 @@ impl Codec for ArrowIpcCodec {
         let writer = StreamWriter::try_new(output, schema.as_ref())?;
         Ok(Box::new(ArrowIpcWriter { schema, writer }))
     }
+
+    fn start_owned_writer(
+        &self,
+        schema: SchemaRef,
+        output: Box<dyn Write + Send>,
+    ) -> Result<Box<dyn CodecWriter>> {
+        let writer = StreamWriter::try_new(output, schema.as_ref())?;
+        Ok(Box::new(ArrowIpcWriter { schema, writer }))
+    }
 }
 
 pub struct ParquetCodec;
 
-struct ParquetWriter<'a> {
+struct ParquetWriter<W: Write + Send> {
     schema: SchemaRef,
-    writer: ArrowWriter<&'a mut (dyn Write + Send)>,
+    writer: ArrowWriter<W>,
 }
 
-impl CodecWriter for ParquetWriter<'_> {
+impl<W: Write + Send> CodecWriter for ParquetWriter<W> {
     fn write_batch(&mut self, batch: &RecordBatch) -> Result<()> {
         validate_batch(&self.schema, batch)?;
         self.writer.write(batch)?;
@@ -256,6 +275,15 @@ impl Codec for ParquetCodec {
         schema: SchemaRef,
         output: &'a mut (dyn Write + Send),
     ) -> Result<Box<dyn CodecWriter + 'a>> {
+        let writer = ArrowWriter::try_new(output, schema.clone(), None)?;
+        Ok(Box::new(ParquetWriter { schema, writer }))
+    }
+
+    fn start_owned_writer(
+        &self,
+        schema: SchemaRef,
+        output: Box<dyn Write + Send>,
+    ) -> Result<Box<dyn CodecWriter>> {
         let writer = ArrowWriter::try_new(output, schema.clone(), None)?;
         Ok(Box::new(ParquetWriter { schema, writer }))
     }
@@ -537,6 +565,29 @@ mod tests {
             let error = writer.write_batch(&mismatched).unwrap_err().to_string();
 
             assert!(error.contains("input schema"));
+        }
+    }
+
+    #[test]
+    fn owned_writers_can_outlive_the_sink_binding() {
+        let (schema, batches) = fixture();
+
+        for format in [DataFormat::Arrow, DataFormat::Parquet] {
+            let codec = DEFAULT_REGISTRY.get(format).unwrap();
+            let sink = SharedSink::default();
+            let observed = sink.clone();
+            let mut writer = codec
+                .start_owned_writer(schema.clone(), Box::new(sink))
+                .unwrap();
+            for batch in &batches {
+                writer.write_batch(batch).unwrap();
+            }
+            writer.finish().unwrap();
+
+            let decoded = codec.decode(&observed.bytes(), None).unwrap();
+            let combined = arrow::compute::concat_batches(&schema, &decoded.batches).unwrap();
+            let expected = arrow::compute::concat_batches(&schema, &batches).unwrap();
+            assert_eq!(combined, expected);
         }
     }
 


### PR DESCRIPTION
## Description

Add Codec::start_owned_writer alongside the borrowed writer API from 0.2.0. Owned sessions accept a boxed Write + Send sink, allowing downstream file objects to store a codec writer without unsafe self-references. Arrow IPC and Parquet share generic writer implementations across borrowed and owned sessions.

This is the missing storage boundary found while integrating resumable writers into fsspec-db. Callers can pass a cloneable shared sink to the writer and retain another handle for draining output.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Documentation update
- [x] Refactor / code cleanup
- [ ] CI / build configuration
- [ ] Other (describe below)

## Checklist

- [x] Linting passes (make lint)
- [x] Tests pass (26 Rust tests and 51 Python tests)
- [x] New tests added for new functionality
- [x] Documentation updated
- [ ] Changelog / version bump (left for release)