### PR TITLE
Add reader-backed codec input

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -133,7 +133,8 @@ Returns `DecodedBatchStream`.
 
 Parameters:
 
-- `data: bytes | bytearray | memoryview`: encoded input.
+- `data: bytes | bytearray | memoryview | BinaryIO`: encoded input. File-like inputs must
+  return `bytes` from `read`; Parquet inputs must also support `seek`.
 - `schema: pyarrow.Schema | None`: required for CSV and JSONL; optional for Arrow IPC and
   Parquet.
 - `batch_size: int`: maximum rows yielded in one batch. Must be greater than zero.
@@ -146,6 +147,18 @@ Parameters:
 Calls `iter_batches(...)`, consumes the stream, and returns `DecodedBatches`. Parameters and
 errors match `iter_batches`.
 
+## Rust `CodecReader`
+
+A marker trait for reader-backed encoded input. Implementations provide `Read + Seek + Send`.
+
+`Codec::decode_reader` accepts a boxed `CodecReader`. The built-in Arrow IPC, Parquet, CSV,
+and JSONL codecs decode directly from the reader. The default implementation for other
+codecs buffers the reader and calls `decode_stream`, preserving compatibility with existing
+`Codec` implementations.
+
+Parquet decoding uses seekable range reads because file metadata and column chunks may be
+located at different offsets.
+
 ## Rust `CodecWriter`
 
 A resumable encoded-output session returned by `Codec::start_writer`.
@@ -157,13 +170,12 @@ Methods:
 - `finish(self: Box<Self>)`: writes the format footer and consumes the session. The borrowed
   sink remains owned by the caller.
 
-Arrow IPC and Parquet codecs support resumable writers. CSV and JSONL return
-`InterchangeError::CodecWriterNotSupported`.
+Arrow IPC, Parquet, CSV, and JSONL codecs support resumable writers.
 
 Arrow IPC makes encoded batch bytes available to the sink during `write_batch`. The Parquet
 writer accepts batches incrementally but may buffer its output until `finish`.
 
-`Codec::encode_stream` uses the same writer session for Arrow IPC and Parquet.
+`Codec::encode_stream` uses the same writer session for all four codecs.
 
 ### `Codec::start_writer(schema, output)`
 

--- a/docs/explanation.md
+++ b/docs/explanation.md
@@ -49,7 +49,17 @@ interchange layer reusable by all of them.
 
 ## Current transport boundary
 
-Python codec methods currently accept encoded input as bytes-like objects. This keeps the
-first public contract small while preserving lazy decoding after the input crosses the
-binding. Reader-backed adapters can extend the transport boundary without changing schema
-planning or batch-stream semantics.
+Python codec methods accept encoded input as bytes-like objects or binary file-like readers.
+Reader-backed input lets row limits and cancellation stop upstream reads before EOF instead
+of requiring the complete encoded source to cross the Python/Rust boundary first.
+
+Parquet readers must be seekable because Parquet metadata is stored in the footer and column
+chunks can reside at different offsets. Arrow IPC, CSV, and JSONL consume readers
+sequentially, but use the same seekable reader contract so registry consumers have one input
+boundary.
+
+`DataFileSystem` opens its inner source through fsspec and decodes from that file object. Its
+converted output remains a buffering adapter: schema application collects decoded batches,
+encoding returns complete output bytes, and `_open()` copies those bytes into a seekable
+spooled file. Reader-backed input removes the initial encoded allocation without making the
+complete chained conversion end-to-end streaming.

--- a/fsspec_data/filesystem.py
+++ b/fsspec_data/filesystem.py
@@ -97,14 +97,14 @@ class DataFileSystem(ChainedFileSystem):
     def _convert(self, path: str) -> bytes:
         provided_format = self.provided_format or _format_from_path(self.fo)
         requested_format = self.requested_format or _format_from_path(path)
-        source = self.fs.cat_file(self.fo)
-        decoded = DEFAULT_REGISTRY.get(provided_format).decode_batches(
-            source,
-            schema=self.provided_schema,
-            batch_size=self.batch_size,
-            row_limit=self.row_limit,
-            byte_limit=self.byte_limit,
-        )
+        with self.fs.open(self.fo, "rb") as source:
+            decoded = DEFAULT_REGISTRY.get(provided_format).decode_batches(
+                source,
+                schema=self.provided_schema,
+                batch_size=self.batch_size,
+                row_limit=self.row_limit,
+                byte_limit=self.byte_limit,
+            )
         if self.provided_schema is not None and not decoded.schema.equals(self.provided_schema, check_metadata=False):
             raise ValueError("provided schema does not match the source schema")
 

--- a/fsspec_data/interchange.py
+++ b/fsspec_data/interchange.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass, replace
 from enum import Enum
 from importlib import import_module
-from typing import Any
+from typing import Any, BinaryIO
 
 import pyarrow as pa
 import pyarrow.compute as pc
@@ -96,7 +96,7 @@ class Codec:
 
     def decode_batches(
         self,
-        data: bytes | bytearray | memoryview,
+        data: bytes | bytearray | memoryview | BinaryIO,
         *,
         schema: pa.Schema | None = None,
         batch_size: int = 1024,
@@ -113,25 +113,35 @@ class Codec:
 
     def iter_batches(
         self,
-        data: bytes | bytearray | memoryview,
+        data: bytes | bytearray | memoryview | BinaryIO,
         *,
         schema: pa.Schema | None = None,
         batch_size: int = 1024,
         row_limit: int | None = None,
         byte_limit: int | None = None,
     ) -> DecodedBatchStream:
-        if not isinstance(data, (bytes, bytearray, memoryview)):
-            raise TypeError("data must be bytes-like")
         if schema is not None:
             schema = _ensure_pyarrow(schema)
-        decoded_schema, native = _rust.decode_stream(
-            self.format.value,
-            bytes(data),
-            schema,
-            batch_size,
-            row_limit,
-            byte_limit,
-        )
+        if isinstance(data, (bytes, bytearray, memoryview)):
+            decoded_schema, native = _rust.decode_stream(
+                self.format.value,
+                bytes(data),
+                schema,
+                batch_size,
+                row_limit,
+                byte_limit,
+            )
+        elif hasattr(data, "read"):
+            decoded_schema, native = _rust.decode_reader(
+                self.format.value,
+                data,
+                schema,
+                batch_size,
+                row_limit,
+                byte_limit,
+            )
+        else:
+            raise TypeError("data must be bytes-like or a binary file-like object")
         return DecodedBatchStream(decoded_schema, native)
 
 
@@ -204,7 +214,7 @@ class InterchangePlan:
 
     def iter_batches(
         self,
-        data: bytes | bytearray | memoryview,
+        data: bytes | bytearray | memoryview | BinaryIO,
         *,
         batch_size: int = 1024,
         row_limit: int | None = None,
@@ -222,7 +232,7 @@ class InterchangePlan:
 
     def convert(
         self,
-        data: bytes | bytearray | memoryview,
+        data: bytes | bytearray | memoryview | BinaryIO,
         *,
         batch_size: int = 1024,
         row_limit: int | None = None,

--- a/fsspec_data/tests/test_all.py
+++ b/fsspec_data/tests/test_all.py
@@ -1,3 +1,5 @@
+import io
+
 import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
@@ -300,6 +302,28 @@ def test_lazy_decode_applies_batch_and_row_limits():
     assert stream.schema == schema
     assert [batch.num_rows for batch in batches] == [2, 2]
     assert pa.Table.from_batches(batches).column("id").to_pylist() == [1, 2, 3, 4]
+
+
+def test_lazy_decode_reads_binary_file_without_eagerly_consuming_it():
+    class CountingReader(io.BytesIO):
+        def __init__(self, data):
+            super().__init__(data)
+            self.bytes_read = 0
+
+        def read(self, size=-1):
+            data = super().read(size)
+            self.bytes_read += len(data)
+            return data
+
+    schema = pa.schema([("id", pa.int64())])
+    batch = pa.record_batch([pa.array(range(1024))], schema=schema)
+    codec = DEFAULT_REGISTRY.get(DataFormat.ARROW)
+    encoded = codec.encode_batches((batch,) * 128)
+    source = CountingReader(encoded)
+    stream = codec.iter_batches(source)
+
+    assert next(stream).num_rows == 1024
+    assert source.bytes_read < len(encoded)
 
 
 def test_lazy_decode_observes_cancellation():

--- a/fsspec_data/tests/test_filesystem.py
+++ b/fsspec_data/tests/test_filesystem.py
@@ -1,3 +1,5 @@
+import io
+
 import fsspec
 import pyarrow as pa
 import pyarrow.parquet as pq
@@ -32,6 +34,32 @@ def test_chained_filesystem_converts_csv_to_seekable_parquet(memory_fs):
 
     assert table.schema.equals(SCHEMA, check_metadata=False)
     assert table.to_pylist() == [{"id": 1, "name": "ada"}, {"id": 2, "name": "grace"}]
+
+
+def test_chained_filesystem_reads_source_without_cat_file(memory_fs, monkeypatch):
+    rows = [f"{index},name-{index}\n".encode() for index in range(50_000)]
+    encoded = b"id,name\n" + b"".join(rows)
+    bytes_read = 0
+
+    class CountingReader(io.BytesIO):
+        def read(self, size=-1):
+            nonlocal bytes_read
+            data = super().read(size)
+            bytes_read += len(data)
+            return data
+
+    monkeypatch.setattr(memory_fs, "open", lambda *args, **kwargs: CountingReader(encoded))
+    monkeypatch.setattr(memory_fs, "cat_file", lambda *args, **kwargs: pytest.fail("cat_file should not be called"))
+    fs = DataFileSystem(
+        fo="orders.csv",
+        fs=memory_fs,
+        provided_schema=SCHEMA_OPTIONS,
+        batch_size=1,
+        row_limit=1,
+    )
+
+    assert pq.read_table(fs.open("orders.parquet")).to_pylist() == [{"id": 0, "name": "name-0"}]
+    assert bytes_read < len(encoded)
 
 
 def test_fsspec_url_builds_chained_filesystem(memory_fs):

--- a/rust/python/lib.rs
+++ b/rust/python/lib.rs
@@ -1,6 +1,8 @@
+use std::io::{self, Read, Seek, SeekFrom};
+
 use ::fsspec_data::{
-    plan_schema as build_plan, CancellationToken, DataFormat, DecodedStream, InterchangeError,
-    SchemaPolicy, StreamOptions, DEFAULT_REGISTRY,
+    plan_schema as build_plan, CancellationToken, CodecReader, DataFormat, DecodedStream,
+    InterchangeError, SchemaPolicy, StreamOptions, DEFAULT_REGISTRY,
 };
 use arrow::array::RecordBatch;
 use arrow::datatypes::Schema;
@@ -9,6 +11,53 @@ use pyo3::prelude::*;
 use pyo3::types::PyBytes;
 
 type MappingTuple = (usize, usize, Option<String>, bool);
+
+struct PythonReader {
+    source: Py<PyAny>,
+}
+
+impl Read for PythonReader {
+    fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+        Python::with_gil(|py| {
+            let data = self
+                .source
+                .bind(py)
+                .call_method1("read", (buffer.len(),))
+                .map_err(python_io_error)?;
+            let data = data
+                .downcast::<PyBytes>()
+                .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error.to_string()))?;
+            let data = data.as_bytes();
+            if data.len() > buffer.len() {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "Python reader returned more bytes than requested",
+                ));
+            }
+            buffer[..data.len()].copy_from_slice(data);
+            Ok(data.len())
+        })
+    }
+}
+
+impl Seek for PythonReader {
+    fn seek(&mut self, position: SeekFrom) -> io::Result<u64> {
+        Python::with_gil(|py| {
+            let source = self.source.bind(py);
+            let position = match position {
+                SeekFrom::Start(offset) => source.call_method1("seek", (offset, 0)),
+                SeekFrom::Current(offset) => source.call_method1("seek", (offset, 1)),
+                SeekFrom::End(offset) => source.call_method1("seek", (offset, 2)),
+            }
+            .map_err(python_io_error)?;
+            position.extract::<u64>().map_err(python_io_error)
+        })
+    }
+}
+
+fn python_io_error(error: PyErr) -> io::Error {
+    io::Error::other(error.to_string())
+}
 
 #[pyclass(unsendable)]
 struct NativeBatchStream {
@@ -116,6 +165,39 @@ fn decode_stream(
 }
 
 #[pyfunction]
+#[pyo3(signature = (format, reader, schema=None, batch_size=1024, row_limit=None, byte_limit=None))]
+fn decode_reader(
+    py: Python<'_>,
+    format: &str,
+    reader: Py<PyAny>,
+    schema: Option<PyArrowType<Schema>>,
+    batch_size: usize,
+    row_limit: Option<usize>,
+    byte_limit: Option<usize>,
+) -> PyResult<(PyArrowType<Schema>, Py<NativeBatchStream>)> {
+    let format = DataFormat::parse(format).map_err(to_python_error)?;
+    let schema = schema.map(|schema| std::sync::Arc::new(schema.0));
+    let reader: Box<dyn CodecReader> = Box::new(PythonReader { source: reader });
+    let stream = DEFAULT_REGISTRY
+        .get(format)
+        .and_then(|codec| {
+            codec.decode_reader(
+                reader,
+                schema,
+                StreamOptions {
+                    batch_size,
+                    row_limit,
+                    byte_limit,
+                },
+                CancellationToken::new(),
+            )
+        })
+        .map_err(to_python_error)?;
+    let schema = PyArrowType(stream.schema.as_ref().clone());
+    Ok((schema, Py::new(py, NativeBatchStream { stream })?))
+}
+
+#[pyfunction]
 fn plan_schema(
     provided: PyArrowType<Schema>,
     requested: PyArrowType<Schema>,
@@ -153,6 +235,7 @@ fn to_python_error(error: InterchangeError) -> PyErr {
         InterchangeError::StreamCancelled => {
             pyo3::exceptions::PyRuntimeError::new_err(error.to_string())
         }
+        InterchangeError::Io(_) => pyo3::exceptions::PyOSError::new_err(error.to_string()),
         _ => pyo3::exceptions::PyValueError::new_err(error.to_string()),
     }
 }
@@ -161,6 +244,7 @@ fn to_python_error(error: InterchangeError) -> PyErr {
 fn fsspec_data(m: &Bound<PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(codec_capabilities, m)?)?;
     m.add_function(wrap_pyfunction!(decode_batches, m)?)?;
+    m.add_function(wrap_pyfunction!(decode_reader, m)?)?;
     m.add_function(wrap_pyfunction!(decode_stream, m)?)?;
     m.add_function(wrap_pyfunction!(encode_batches, m)?)?;
     m.add_function(wrap_pyfunction!(plan_schema, m)?)?;

--- a/rust/src/codec.rs
+++ b/rust/src/codec.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
-use std::io::{Cursor, Write};
-use std::sync::{Arc, LazyLock};
+use std::io::{self, BufReader, Cursor, Read, Seek, SeekFrom, Write};
+use std::sync::{Arc, LazyLock, Mutex};
 
 use arrow::array::RecordBatch;
 use arrow::csv::{
@@ -13,6 +13,8 @@ use arrow::json::{LineDelimitedWriter, ReaderBuilder as JsonReaderBuilder};
 use bytes::Bytes;
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use parquet::arrow::ArrowWriter;
+use parquet::errors::ParquetError;
+use parquet::file::reader::{ChunkReader, Length};
 
 use crate::{
     CancellationToken, DataFormat, DecodedStream, InterchangeError, Result, StreamOptions,
@@ -35,6 +37,10 @@ pub trait CodecWriter: Send {
     fn finish(self: Box<Self>) -> Result<()>;
 }
 
+pub trait CodecReader: Read + Seek + Send {}
+
+impl<T: Read + Seek + Send> CodecReader for T {}
+
 pub trait Codec: Send + Sync {
     fn format(&self) -> DataFormat;
     fn capabilities(&self) -> CodecCapabilities;
@@ -51,6 +57,18 @@ pub trait Codec: Send + Sync {
         options: StreamOptions,
         cancellation: CancellationToken,
     ) -> Result<DecodedStream>;
+
+    fn decode_reader(
+        &self,
+        mut reader: Box<dyn CodecReader>,
+        schema: Option<SchemaRef>,
+        options: StreamOptions,
+        cancellation: CancellationToken,
+    ) -> Result<DecodedStream> {
+        let mut data = Vec::new();
+        reader.read_to_end(&mut data)?;
+        self.decode_stream(data, schema, options, cancellation)
+    }
 
     fn start_writer<'a>(
         &self,
@@ -177,7 +195,17 @@ impl Codec for ArrowIpcCodec {
         options: StreamOptions,
         cancellation: CancellationToken,
     ) -> Result<DecodedStream> {
-        let reader = StreamReader::try_new(Cursor::new(data), None)?;
+        self.decode_reader(Box::new(Cursor::new(data)), None, options, cancellation)
+    }
+
+    fn decode_reader(
+        &self,
+        reader: Box<dyn CodecReader>,
+        _schema: Option<SchemaRef>,
+        options: StreamOptions,
+        cancellation: CancellationToken,
+    ) -> Result<DecodedStream> {
+        let reader = StreamReader::try_new(reader, None)?;
         let schema = reader.schema();
         DecodedStream::new(
             schema,
@@ -207,6 +235,68 @@ impl Codec for ArrowIpcCodec {
 }
 
 pub struct ParquetCodec;
+
+struct SharedReader {
+    reader: Arc<Mutex<Box<dyn CodecReader>>>,
+    position: u64,
+}
+
+impl Read for SharedReader {
+    fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+        let mut reader = self
+            .reader
+            .lock()
+            .map_err(|_| io::Error::other("parquet reader lock is poisoned"))?;
+        reader.seek(SeekFrom::Start(self.position))?;
+        let read = reader.read(buffer)?;
+        self.position += read as u64;
+        Ok(read)
+    }
+}
+
+struct SeekableChunkReader {
+    reader: Arc<Mutex<Box<dyn CodecReader>>>,
+    len: u64,
+}
+
+impl SeekableChunkReader {
+    fn new(mut reader: Box<dyn CodecReader>) -> Result<Self> {
+        let len = reader.seek(SeekFrom::End(0))?;
+        reader.seek(SeekFrom::Start(0))?;
+        Ok(Self {
+            reader: Arc::new(Mutex::new(reader)),
+            len,
+        })
+    }
+}
+
+impl Length for SeekableChunkReader {
+    fn len(&self) -> u64 {
+        self.len
+    }
+}
+
+impl ChunkReader for SeekableChunkReader {
+    type T = SharedReader;
+
+    fn get_read(&self, start: u64) -> parquet::errors::Result<Self::T> {
+        Ok(SharedReader {
+            reader: Arc::clone(&self.reader),
+            position: start,
+        })
+    }
+
+    fn get_bytes(&self, start: u64, length: usize) -> parquet::errors::Result<Bytes> {
+        let mut reader = self
+            .reader
+            .lock()
+            .map_err(|_| ParquetError::General("parquet reader lock is poisoned".to_string()))?;
+        reader.seek(SeekFrom::Start(start))?;
+        let mut buffer = vec![0; length];
+        reader.read_exact(&mut buffer)?;
+        Ok(buffer.into())
+    }
+}
 
 struct ParquetWriter<W: Write + Send> {
     schema: SchemaRef,
@@ -260,8 +350,19 @@ impl Codec for ParquetCodec {
         options: StreamOptions,
         cancellation: CancellationToken,
     ) -> Result<DecodedStream> {
-        let builder = ParquetRecordBatchReaderBuilder::try_new(Bytes::from(data))?
-            .with_batch_size(options.batch_size);
+        self.decode_reader(Box::new(Cursor::new(data)), None, options, cancellation)
+    }
+
+    fn decode_reader(
+        &self,
+        reader: Box<dyn CodecReader>,
+        _schema: Option<SchemaRef>,
+        options: StreamOptions,
+        cancellation: CancellationToken,
+    ) -> Result<DecodedStream> {
+        let reader = SeekableChunkReader::new(reader)?;
+        let builder =
+            ParquetRecordBatchReaderBuilder::try_new(reader)?.with_batch_size(options.batch_size);
         let schema = builder.schema().clone();
         let reader = builder.build()?;
         DecodedStream::new(
@@ -343,11 +444,21 @@ impl Codec for CsvCodec {
         options: StreamOptions,
         cancellation: CancellationToken,
     ) -> Result<DecodedStream> {
+        self.decode_reader(Box::new(Cursor::new(data)), schema, options, cancellation)
+    }
+
+    fn decode_reader(
+        &self,
+        reader: Box<dyn CodecReader>,
+        schema: Option<SchemaRef>,
+        options: StreamOptions,
+        cancellation: CancellationToken,
+    ) -> Result<DecodedStream> {
         let schema = required_schema(DataFormat::Csv, schema)?;
         let reader = CsvReaderBuilder::new(schema.clone())
             .with_header(true)
             .with_batch_size(options.batch_size)
-            .build(Cursor::new(data))?;
+            .build(reader)?;
         DecodedStream::new(
             schema,
             Box::new(reader.map(|batch| batch.map_err(InterchangeError::from))),
@@ -428,10 +539,20 @@ impl Codec for JsonLinesCodec {
         options: StreamOptions,
         cancellation: CancellationToken,
     ) -> Result<DecodedStream> {
+        self.decode_reader(Box::new(Cursor::new(data)), schema, options, cancellation)
+    }
+
+    fn decode_reader(
+        &self,
+        reader: Box<dyn CodecReader>,
+        schema: Option<SchemaRef>,
+        options: StreamOptions,
+        cancellation: CancellationToken,
+    ) -> Result<DecodedStream> {
         let schema = required_schema(DataFormat::JsonLines, schema)?;
         let reader = JsonReaderBuilder::new(schema.clone())
             .with_batch_size(options.batch_size)
-            .build(Cursor::new(data))?;
+            .build(BufReader::new(reader))?;
         DecodedStream::new(
             schema,
             Box::new(reader.map(|batch| batch.map_err(InterchangeError::from))),
@@ -473,6 +594,7 @@ fn validate_batch(schema: &SchemaRef, batch: &RecordBatch) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use std::io;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Mutex;
 
     use arrow::array::{Int64Array, RecordBatch, StringArray};
@@ -501,6 +623,38 @@ mod tests {
 
         fn flush(&mut self) -> io::Result<()> {
             Ok(())
+        }
+    }
+
+    struct CountingReader {
+        inner: Cursor<Vec<u8>>,
+        bytes_read: Arc<AtomicUsize>,
+    }
+
+    impl CountingReader {
+        fn new(data: Vec<u8>) -> (Self, Arc<AtomicUsize>) {
+            let bytes_read = Arc::new(AtomicUsize::new(0));
+            (
+                Self {
+                    inner: Cursor::new(data),
+                    bytes_read: Arc::clone(&bytes_read),
+                },
+                bytes_read,
+            )
+        }
+    }
+
+    impl Read for CountingReader {
+        fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+            let read = self.inner.read(buffer)?;
+            self.bytes_read.fetch_add(read, Ordering::Relaxed);
+            Ok(read)
+        }
+    }
+
+    impl Seek for CountingReader {
+        fn seek(&mut self, position: SeekFrom) -> io::Result<u64> {
+            self.inner.seek(position)
         }
     }
 
@@ -575,6 +729,64 @@ mod tests {
 
         assert_eq!(decoded.schema, schema);
         assert!(decoded.batches.is_empty());
+    }
+
+    #[test]
+    fn reader_backed_decoding_round_trips_all_formats() {
+        let (schema, batches) = fixture();
+
+        for format in [
+            DataFormat::Arrow,
+            DataFormat::Parquet,
+            DataFormat::Csv,
+            DataFormat::JsonLines,
+        ] {
+            let codec = DEFAULT_REGISTRY.get(format).unwrap();
+            let encoded = codec.encode(schema.clone(), &batches).unwrap();
+            let decode_schema = match format {
+                DataFormat::Csv | DataFormat::JsonLines => Some(schema.clone()),
+                DataFormat::Arrow | DataFormat::Parquet => None,
+            };
+            let (reader, _) = CountingReader::new(encoded);
+            let decoded = codec
+                .decode_reader(
+                    Box::new(reader),
+                    decode_schema,
+                    StreamOptions::default(),
+                    CancellationToken::new(),
+                )
+                .unwrap();
+            let decoded_schema = decoded.schema.clone();
+            let decoded_batches = decoded.collect_batches().unwrap();
+
+            assert_eq!(decoded_schema, schema);
+            let combined = arrow::compute::concat_batches(&schema, &decoded_batches).unwrap();
+            let expected = arrow::compute::concat_batches(&schema, &batches).unwrap();
+            assert_eq!(combined, expected);
+        }
+    }
+
+    #[test]
+    fn arrow_reader_does_not_eagerly_consume_complete_input() {
+        let (schema, fixture_batches) = fixture();
+        let batches = (0..128)
+            .flat_map(|_| fixture_batches.iter().cloned())
+            .collect::<Vec<_>>();
+        let codec = DEFAULT_REGISTRY.get(DataFormat::Arrow).unwrap();
+        let encoded = codec.encode(schema, &batches).unwrap();
+        let encoded_len = encoded.len();
+        let (reader, bytes_read) = CountingReader::new(encoded);
+        let mut decoded = codec
+            .decode_reader(
+                Box::new(reader),
+                None,
+                StreamOptions::default(),
+                CancellationToken::new(),
+            )
+            .unwrap();
+
+        assert!(decoded.next().unwrap().is_ok());
+        assert!(bytes_read.load(Ordering::Relaxed) < encoded_len);
     }
 
     #[test]

--- a/rust/src/error.rs
+++ b/rust/src/error.rs
@@ -65,6 +65,8 @@ pub enum InterchangeError {
     #[error("decoded batch memory exceeds byte limit {limit}: attempted {attempted}")]
     ByteLimitExceeded { limit: usize, attempted: usize },
     #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error(transparent)]
     Arrow(#[from] arrow::error::ArrowError),
     #[error(transparent)]
     Parquet(#[from] parquet::errors::ParquetError),

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -4,8 +4,8 @@ mod plan;
 mod stream;
 
 pub use codec::{
-    ArrowIpcCodec, Codec, CodecCapabilities, CodecRegistry, CodecWriter, CsvCodec, DecodedBatches,
-    JsonLinesCodec, ParquetCodec, DEFAULT_REGISTRY,
+    ArrowIpcCodec, Codec, CodecCapabilities, CodecReader, CodecRegistry, CodecWriter, CsvCodec,
+    DecodedBatches, JsonLinesCodec, ParquetCodec, DEFAULT_REGISTRY,
 };
 pub use error::{InterchangeError, Result};
 pub use plan::{


### PR DESCRIPTION
## Description

Add reader-backed decoding for Rust and Python codecs while preserving bytes-backed APIs. Decode fsspec sources through opened file objects, including seekable Parquet range reads, so limits can stop sequential reads before EOF.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup
- [ ] CI / build configuration
- [ ] Other (describe below)

## Checklist

- [x] Linting passes (`make lint`)
- [x] Tests pass (`make test`)
- [x] New tests added for new functionality
- [x] Documentation updated (if applicable)
- [x] Changelog / version bump (not applicable)