### PR TITLE
Fix lint errors

### DIFF
--- a/fsspec_data/__init__.py
+++ b/fsspec_data/__init__.py
@@ -18,12 +18,12 @@ from .interchange import (
 __version__ = "0.2.3"
 
 __all__ = [
+    "DEFAULT_REGISTRY",
     "Codec",
     "CodecCapabilities",
     "CodecRegistry",
-    "DEFAULT_REGISTRY",
-    "DataFormat",
     "DataFileSystem",
+    "DataFormat",
     "DecodedBatchStream",
     "DecodedBatches",
     "FieldMapping",

--- a/fsspec_data/backends/base.py
+++ b/fsspec_data/backends/base.py
@@ -27,7 +27,6 @@ class BaseFileSystem(AbstractFileSystem):
         kwargs:
             may be permissions, etc.
         """
-        ...
 
     def makedirs(self, path, exist_ok=False):
         """Recursively make directories
@@ -43,11 +42,9 @@ class BaseFileSystem(AbstractFileSystem):
         exist_ok: bool (False)
             If False, will error if the target already exists
         """
-        ...
 
     def rmdir(self, path):
         """Remove a directory, if empty"""
-        ...
 
     def ls(self, path, detail=True, **kwargs):
         """List objects at path.
@@ -204,7 +201,6 @@ class BaseBufferedFile(AbstractBufferedFile):
 
     def _initiate_upload(self):
         """Create remote file/upload"""
-        pass
 
     def _fetch_range(self, start, end):
         """Get the specified set of bytes from remote"""

--- a/fsspec_data/filesystem.py
+++ b/fsspec_data/filesystem.py
@@ -70,7 +70,7 @@ class DataFileSystem(ChainedFileSystem):
             raise ValueError("fsspec-data is a read-only filesystem")
 
         path = self._strip_protocol(path)
-        file = tempfile.SpooledTemporaryFile(max_size=self.spool_max_size, mode="w+b")
+        file = tempfile.SpooledTemporaryFile(max_size=self.spool_max_size, mode="w+b")  # noqa: SIM115
         try:
             self._convert(path, file)
             self._sizes[path] = file.tell()

--- a/fsspec_data/tests/conftest.py
+++ b/fsspec_data/tests/conftest.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 import pytest
 
 


### PR DESCRIPTION
Updates code for the latest Ruff diagnostics without changing lint configuration. `make lint` passes.