### PR TITLE
Add schema references and extensible converters

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -15,10 +15,10 @@ Constructor parameters:
 - `provided_format: DataFormat | str | None`: source format. Inferred from `fo` when omitted.
 - `requested_format: DataFormat | str | None`: output format. Inferred from the opened path
   when omitted.
-- `provided_schema`: source `pyarrow.Schema` or nested schema options. Required for CSV and
-  JSONL.
-- `requested_schema`: output `pyarrow.Schema` or nested schema options. Defaults to the source
-  schema.
+- `provided_schema`: source `pyarrow.Schema`, nested schema options, or schema reference.
+  Required for CSV and JSONL.
+- `requested_schema`: output `pyarrow.Schema`, nested schema options, or schema reference.
+  Defaults to the source schema.
 - `schema_policy: SchemaPolicy | str`: reconciliation policy. Defaults to `exact`.
 - `batch_size: int`: maximum rows per decoded batch. Defaults to `1024`.
 - `row_limit: int | None`: maximum decoded rows.
@@ -30,6 +30,27 @@ Nested schema options have a `fields` list. Each field has `name`, `type`, and o
 `nullable` keys. String types use PyArrow aliases such as `int64`, `string`, and
 `timestamp[ms]`.
 
+A schema reference is a `SchemaRef`, URL string, or mapping with `url`, optional `format`, and
+optional `storage_options`. Reference storage options apply only to that schema source.
+Built-in formats are `arrow-json` for nested field descriptors, `arrow-ipc-schema` for a
+serialized Arrow schema or IPC stream, and `json-schema` for the supported structural JSON
+Schema subset. `.arrow`, `.ipc`, and `.arrowschema` infer `arrow-ipc-schema`; ambiguous
+extensions require an explicit format.
+
+The `confluent://SUBJECT/versions/VERSION` provider accepts `latest`, `-1`, or a positive
+32-bit integer as `VERSION`, and these `storage_options`:
+
+- `registry_url: str`: required HTTP or HTTPS Schema Registry base URL.
+- `username: str` and `password: str`: optional Basic authentication pair.
+- `headers: Mapping[str, str]`: optional additional request headers.
+- `timeout: int | float`: optional request timeout in seconds.
+
+The provider supports registry documents with `schemaType` `JSON` and no external schema
+references. Avro, Protobuf, and referenced documents raise `ValueError`.
+
+After conversion starts, `provided_schema_provenance` and `requested_schema_provenance`
+describe resolved schema sources without exposing storage options.
+
 Recognized suffixes are `.arrow` and `.ipc` for Arrow IPC streams, `.parquet` and `.pq` for
 Parquet, `.csv` for CSV, and `.jsonl` and `.ndjson` for line-delimited JSON.
 
@@ -37,6 +58,138 @@ Parquet, `.csv` for CSV, and `.jsonl` and `.ndjson` for line-delimited JSON.
 complete encoded source and produces a complete encoded output before returning the file.
 
 See [How to convert a file through an fsspec chain](how-to-chain-filesystems.md) for usage.
+
+## `SchemaRef`
+
+Identifies an independently resolvable schema.
+
+Attributes:
+
+- `url: str`: schema location.
+- `format: SchemaFormat | str | None`: schema representation. Inferred for recognized Arrow
+  schema suffixes.
+- `storage_options: Mapping[str, Any]`: options passed only to the schema filesystem. Omitted
+  from `repr`.
+
+## `ResolvedSchema`
+
+Contains the resolved `pyarrow.Schema` and `SchemaProvenance`. Resolution performs I/O before
+interchange planning; the planner continues to receive only Arrow schemas.
+
+## `SchemaProvenance`
+
+Describes a resolved schema without credentials.
+
+Attributes:
+
+- `source: str`: original schema reference URL or `inline`.
+- `format: str`: decoded schema representation.
+- `provider: str`: `inline`, `fsspec`, `confluent`, or a registered provider name.
+- `identifier: str | None`: provider-specific schema identifier.
+- `version: str | None`: provider-specific schema version.
+
+## `SchemaDocument`
+
+Contains provider-returned schema bytes, their `SchemaFormat`, and `SchemaProvenance`.
+
+## `SchemaResolverRegistry`
+
+Separates schema transport providers from schema-language decoders.
+
+### `register(format, decoder)`
+
+Registers a decoder accepting schema `bytes` and returning `pyarrow.Schema`.
+
+### `register_provider(protocol, provider)`
+
+Registers a provider accepting `SchemaRef` and returning `SchemaDocument`.
+
+`DEFAULT_SCHEMA_RESOLVERS` includes decoders for `arrow-json`, `arrow-ipc-schema`, and
+`json-schema`; a `confluent` provider; and an fsspec provider fallback for other protocols.
+
+Use `resolve_schema` to resolve an inline schema or normalized `SchemaRef` directly.
+
+## `json_schema_to_arrow`
+
+Converts the supported JSON Schema subset directly to `pyarrow.Schema`. The root must have
+type `object`. Supported value types are object, array with one `items` schema, string,
+boolean, integer as Arrow `int64`, number as Arrow `float64`, and null. A type array may contain
+null and one non-null type.
+
+Object `required` entries and null unions determine Arrow field nullability. References,
+composition, multiple non-null union members, tuple arrays, schema-valued additional
+properties, and `format` annotations raise `ValueError` with a schema path. JSON Schema
+validation constraints are not represented or enforced by Arrow.
+
+## `Converter`
+
+Describes one native conversion route.
+
+Attributes:
+
+- `source_type: str`: normalized, case-insensitive source type.
+- `target_type: str`: normalized, case-insensitive target type.
+- `handler: Callable`: conversion function, omitted from `repr`.
+
+The handler signature is:
+
+```python
+handler(
+    source,
+    target,
+    *,
+    source_options,
+    target_options,
+    conversion_options,
+)
+```
+
+All option arguments are dictionaries. The handler return value is the converter result.
+
+### `convert(source, target=None, *, source_options=None, target_options=None, conversion_options=None)`
+
+Copies the three option mappings and calls the handler. Raises `TypeError` when an option
+value is not a mapping.
+
+## `ConverterRegistry`
+
+Maps normalized `(source_type, target_type)` pairs to `Converter` objects. Installed converter
+entry points are loaded at most once, on first lookup.
+
+Constructor parameters:
+
+- `entry_point_group: str`: discovery group. Defaults to `fsspec_data.converters`.
+- `discover_entry_points: bool`: enables installed entry-point discovery. Defaults to `True`.
+
+### `register(converter, *, replace=False)`
+
+Registers a `Converter`. Raises `ValueError` for a duplicate route unless `replace=True`.
+
+### `load_entry_points()`
+
+Loads entry points from the configured group. Each entry point must load one `Converter`.
+Duplicate routes and invalid objects raise errors before discovered converters are added.
+
+### `get(source_type, target_type)`
+
+Returns the converter for a route. Raises `ValueError` when no converter is registered.
+
+### `convert(source_type, target_type, source, target=None, **options)`
+
+Gets the route and calls `Converter.convert`.
+
+## `DEFAULT_CONVERTERS`
+
+Default `ConverterRegistry`. Built-in routes are `zarr` to `xarray` and `xarray` to `zarr`.
+They import Xarray only when invoked and require the `fsspec-data[xarray]` optional dependency.
+
+The Zarr-to-Xarray route calls `xarray.open_zarr`. `source_options` become its
+`storage_options`; `conversion_options` supply options such as `group` and `chunks`. It returns
+an Xarray `Dataset` and rejects a target or target options.
+
+The Xarray-to-Zarr route accepts an Xarray `Dataset` or `DataArray` and calls `to_zarr`.
+`target_options` become its `storage_options`; `conversion_options` supply options such as
+`mode`, `group`, and `zarr_format`.
 
 ## `DataFormat`
 

--- a/docs/explanation.md
+++ b/docs/explanation.md
@@ -4,6 +4,70 @@
 packages that consume it. It reconciles formats and schemas without absorbing database,
 dataframe, or user-interface responsibilities.
 
+## Data, schemas, projection, and conversion
+
+Three independently located inputs define one interchange request: data source A, provided
+schema B, and requested schema C. B describes how to interpret A. C describes the columns and
+types the consumer wants. A projection is the logical mapping from B to C; conversion is the
+physical decoding and encoding around that mapping.
+
+```mermaid
+flowchart LR
+    A["A · Data source<br/>database · S3 · filesystem"]
+    B["B · Provided schema<br/>inline · file · registry"]
+    C["C · Requested schema<br/>inline · file · registry"]
+
+    B --> RB["Resolve with B credentials"]
+    C --> RC["Resolve with C credentials"]
+    RB --> BS["Provided Arrow schema"]
+    RC --> CS["Requested Arrow schema"]
+    BS --> P["Projection plan<br/>select · reorder · rename · add · cast"]
+    CS --> P
+
+    A --> D["Decode source format"]
+    D --> AB["Arrow record batches"]
+    AB --> X["Apply projection"]
+    P --> X
+    X --> E["Encode requested format"]
+    E --> O["Requested representation<br/>Parquet · Arrow · CSV · JSONL"]
+
+    A -.->|native model/store route| R["Converter registry<br/>built-in · entry point"]
+    R --> N["Native conversion<br/>Xarray ↔ Zarr · plugin X ↔ Y"]
+    N --> NO["Native target<br/>object · store · resource"]
+
+    classDef external fill:#eef5ff,stroke:#4c78a8,color:#152238
+    classDef schema fill:#f4eeff,stroke:#7a5195,color:#24152e
+    classDef operation fill:#fff4df,stroke:#d28e2c,color:#38250a
+    classDef arrow fill:#e8f6ef,stroke:#3a8f67,color:#102d21
+    class A,B,C,O,NO external
+    class RB,RC,BS,CS schema
+    class D,P,X,E,R,N operation
+    class AB arrow
+```
+
+Schema resolution may perform I/O, but it completes before source data is opened. Each
+reference carries only its own storage or registry credentials. Once B and C are Arrow
+schemas, planning is pure: it validates the requested projection without reading A. Execution
+then decodes, applies that stable plan batch by batch, and encodes the requested representation.
+
+## Why resource converters sit beside Arrow codecs
+
+Arrow batches are the right boundary for tabular, single-object formats. They are not a
+lossless universal representation for every data model. An Xarray dataset can contain
+N-dimensional variables, named dimensions, coordinates, and attributes, while a Zarr group
+is a hierarchy of metadata and chunk objects rather than one seekable file.
+
+Forcing those resources through the file-codec path would either flatten model semantics or
+pretend a multi-object store is one file. The converter registry therefore provides a sibling
+route. A converter owns the semantics of its source and target types and may return an object,
+write a store, or use Arrow internally when that is appropriate. Entry-point discovery lets
+integration packages add routes without adding their dependencies or release cadence to
+`fsspec-data`.
+
+`DataFileSystem` remains the read-only façade for single-file tabular conversion. Native
+resource conversion uses `ConverterRegistry` directly because its output may not satisfy a
+file-like `open()` contract.
+
 ## Arrow is the internal boundary
 
 Arrow provides one typed, columnar representation for schema comparison, casting, and
@@ -17,7 +81,16 @@ integration enters through Rust or PyArrow.
 
 ## Planning precedes execution
 
-An `InterchangeRequest` separates validation from data access. Planning checks that codecs,
+External schema references are resolved to Arrow schemas before an `InterchangeRequest` is
+created. Resolution may read another filesystem or registry and records schema provenance;
+it is separate from planning.
+
+JSON Schema resolution translates only structural type information. Arrow schemas do not
+encode the complete JSON Schema validation language, so composition, references, ambiguous
+unions, and format-dependent conversions are rejected. Validation-only constraints are not
+enforced during interchange.
+
+An `InterchangeRequest` separates validation from source-data access. Planning checks that codecs,
 field mappings, nullability changes, and casts can satisfy the requested contract without
 reading input. Execution then applies that stable plan to each batch.
 
@@ -42,7 +115,8 @@ for scans and previews.
   database-to-Arrow mapping.
 - Dataframe integrations own expression translation and local fallback execution.
 - Browsers own pagination, rendering, and request lifecycles.
-- `fsspec-data` owns format codecs, schema reconciliation, casts, and interchange limits.
+- `fsspec-data` owns schema resolution, projections, format conversion, casts, and
+  interchange limits.
 
 These boundaries keep backend-specific semantics close to each backend and make the
 interchange layer reusable by all of them.

--- a/docs/how-to-chain-filesystems.md
+++ b/docs/how-to-chain-filesystems.md
@@ -20,6 +20,65 @@ schema = {
 Pass a `pyarrow.Schema` instead when the chain remains in Python. Arrow IPC and Parquet
 sources provide their own schemas, so `provided_schema` is optional for those formats.
 
+## Resolve schemas from independent filesystems
+
+Use a schema reference when a schema is stored separately from the data. Each reference owns
+its storage options, so provided and requested schemas can use different backends or
+credentials:
+
+```python
+provided_schema = {
+    "url": "s3://input-schemas/orders.json",
+    "format": "arrow-json",
+    "storage_options": {"profile": "input-schema-reader"},
+}
+requested_schema = {
+    "url": "s3://output-schemas/orders.schema.json",
+    "format": "json-schema",
+    "storage_options": {"profile": "output-schema-reader"},
+}
+```
+
+`arrow-json` uses the `fields` descriptor shown above. `arrow-ipc-schema` accepts bytes from
+`pyarrow.Schema.serialize()` or an Arrow IPC stream. A string URL is shorthand for a reference
+when its suffix identifies an Arrow IPC schema:
+
+```python
+requested_schema = "s3://output-schemas/orders.arrow"
+```
+
+`json-schema` accepts a structural JSON Schema whose root is an object. It maps JSON Schema
+objects, arrays with one `items` schema, strings, booleans, integers, numbers, and nulls to
+Arrow. A union may contain null and one other type. Object `required` entries determine Arrow
+field nullability; optional properties and explicit null unions are nullable.
+
+References, composition keywords, multiple non-null union members, schema-valued
+`additionalProperties`, tuple arrays, and `format` annotations are rejected with a path to the
+unsupported field. Validation-only keywords such as numeric bounds and string lengths are not
+represented or enforced by the Arrow schema.
+
+## Resolve JSON Schema from Confluent Schema Registry
+
+Use a `confluent://SUBJECT/versions/VERSION` reference for a JSON Schema registered with
+Confluent. Put registry connection options on that reference:
+
+```python
+provided_schema = {
+    "url": "confluent://orders-value/versions/latest",
+    "format": "json-schema",
+    "storage_options": {
+        "registry_url": "https://schema-registry.example.com",
+        "username": "schema-api-key",
+        "password": "schema-api-secret",
+        "timeout": 10,
+    },
+}
+```
+
+Pass `headers` in `storage_options` for additional string-valued HTTP headers. The resolver
+supports JSON Schema records without external schema references. It rejects Avro, Protobuf,
+and registry records that contain references.
+
 ## Open the converted representation
 
 Place the requested representation on the left and the source object on the right:
@@ -43,12 +102,16 @@ To project, reorder, or cast fields, pass `requested_schema` and the correspondi
 ```python
 with fsspec.open(
     url,
-    provided_schema=schema,
-    requested_schema={"fields": [{"name": "name", "type": "string"}]},
+    provided_schema=provided_schema,
+    requested_schema=requested_schema,
     schema_policy="projection",
 ) as file:
     names = pq.read_table(file)
 ```
+
+The data filesystem and each schema reference keep separate options. For example, the inner
+S3 URL can use fsspec's `s3` options while the provided and requested schema references use
+different registry credentials.
 
 For a database source, pass connection settings to the inner protocol:
 

--- a/docs/how-to-integrate.md
+++ b/docs/how-to-integrate.md
@@ -63,6 +63,81 @@ with open("result.arrow", "wb") as output:
     )
 ```
 
+## Convert between Xarray and Zarr
+
+Install the optional dependencies:
+
+```console
+pip install "fsspec-data[xarray]"
+```
+
+Open a Zarr store as an Xarray dataset while keeping storage credentials scoped to the source:
+
+```python
+from fsspec_data import DEFAULT_CONVERTERS
+
+dataset = DEFAULT_CONVERTERS.convert(
+    "zarr",
+    "xarray",
+    "s3://weather-input/forecast.zarr",
+    source_options={"profile": "weather-reader"},
+    conversion_options={"group": "forecast", "chunks": "auto"},
+)
+```
+
+Write a dataset to another Zarr store with independent target credentials:
+
+```python
+DEFAULT_CONVERTERS.convert(
+    "xarray",
+    "zarr",
+    dataset,
+    "s3://weather-output/forecast.zarr",
+    target_options={"profile": "weather-writer"},
+    conversion_options={"mode": "w-", "zarr_format": 3},
+)
+```
+
+Use the converter API rather than `DataFileSystem.open()` for Zarr because a Zarr hierarchy
+contains multiple metadata and chunk objects.
+
+## Register a converter through an entry point
+
+Expose one `Converter` object from the integration package:
+
+```python
+from fsspec_data import Converter
+
+
+def geotiff_to_xarray(
+    source,
+    target,
+    *,
+    source_options,
+    target_options,
+    conversion_options,
+):
+    ...
+
+
+GEOTIFF_TO_XARRAY = Converter("geotiff", "xarray", geotiff_to_xarray)
+```
+
+Register that object in the package's `pyproject.toml`:
+
+```toml
+[project.entry-points."fsspec_data.converters"]
+geotiff-xarray = "my_package.converters:GEOTIFF_TO_XARRAY"
+```
+
+Installed entry points are discovered on the registry's first lookup. Keep optional heavy
+imports inside the converter handler so loading its descriptor remains inexpensive. Route
+names are case-insensitive. Duplicate source-target routes raise an error instead of selecting
+one by installation order.
+
+Call `DEFAULT_CONVERTERS.register(converter)` instead when registration is local to one
+process and does not need package discovery.
+
 ## Integrate from Rust
 
 Compose registered codecs with the plan's stream adapter:

--- a/fsspec_data/__init__.py
+++ b/fsspec_data/__init__.py
@@ -1,3 +1,9 @@
+from .converters import (
+    CONVERTER_ENTRY_POINT_GROUP,
+    DEFAULT_CONVERTERS,
+    Converter,
+    ConverterRegistry,
+)
 from .filesystem import DataFileSystem
 from .interchange import (
     DEFAULT_REGISTRY,
@@ -14,14 +20,30 @@ from .interchange import (
     SchemaPolicy,
     plan_schema,
 )
+from .json_schema import json_schema_to_arrow
+from .schema import (
+    DEFAULT_SCHEMA_RESOLVERS,
+    ResolvedSchema,
+    SchemaDocument,
+    SchemaFormat,
+    SchemaProvenance,
+    SchemaRef,
+    SchemaResolverRegistry,
+    resolve_schema,
+)
 
 __version__ = "0.2.3"
 
 __all__ = [
+    "CONVERTER_ENTRY_POINT_GROUP",
+    "DEFAULT_CONVERTERS",
     "DEFAULT_REGISTRY",
+    "DEFAULT_SCHEMA_RESOLVERS",
     "Codec",
     "CodecCapabilities",
     "CodecRegistry",
+    "Converter",
+    "ConverterRegistry",
     "DataFileSystem",
     "DataFormat",
     "DecodedBatchStream",
@@ -30,7 +52,15 @@ __all__ = [
     "InterchangePlan",
     "InterchangeRequest",
     "PlannedBatchStream",
+    "ResolvedSchema",
+    "SchemaDocument",
+    "SchemaFormat",
     "SchemaPolicy",
+    "SchemaProvenance",
+    "SchemaRef",
+    "SchemaResolverRegistry",
     "__version__",
+    "json_schema_to_arrow",
     "plan_schema",
+    "resolve_schema",
 ]

--- a/fsspec_data/confluent.py
+++ b/fsspec_data/confluent.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from base64 import b64encode
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import quote, unquote, urlsplit
+
+
+@dataclass(frozen=True)
+class ConfluentSchemaDocument:
+    schema: str
+    schema_type: str
+    subject: str
+    version: str
+    schema_id: str | None
+    references: tuple[Mapping[str, Any], ...]
+
+
+def fetch_confluent_schema(url: str, storage_options: Mapping[str, Any]) -> ConfluentSchemaDocument:
+    subject, requested_version = _parse_reference(url)
+    options = dict(storage_options)
+    try:
+        registry_url = options.pop("registry_url")
+    except KeyError as error:
+        raise ValueError("Confluent schema references require storage_options['registry_url']") from error
+    if not isinstance(registry_url, str) or not registry_url.startswith(("http://", "https://")):
+        raise ValueError("Confluent registry_url must be an HTTP or HTTPS URL")
+
+    username = options.pop("username", None)
+    password = options.pop("password", None)
+    if (
+        (username is None) != (password is None)
+        or (username is not None and not isinstance(username, str))
+        or (password is not None and not isinstance(password, str))
+    ):
+        raise ValueError("Confluent username and password must be strings provided together")
+    headers = options.pop("headers", {})
+    if not isinstance(headers, Mapping) or not all(isinstance(key, str) and isinstance(value, str) for key, value in headers.items()):
+        raise TypeError("Confluent headers must map strings to strings")
+    timeout = options.pop("timeout", None)
+    if timeout is not None and not isinstance(timeout, (int, float)):
+        raise TypeError("Confluent timeout must be a number")
+    if options:
+        raise ValueError(f"unknown Confluent storage options: {', '.join(sorted(options))}")
+
+    endpoint = f"{registry_url.rstrip('/')}/subjects/{quote(subject, safe='')}/versions/{quote(requested_version, safe='')}"
+    request_headers = {
+        "Accept": "application/vnd.schemaregistry.v1+json, application/json",
+        **dict(headers),
+    }
+    if username is not None and password is not None:
+        token = b64encode(f"{username}:{password}".encode()).decode()
+        request_headers["Authorization"] = f"Basic {token}"
+    request = urllib.request.Request(endpoint, headers=request_headers, method="GET")
+
+    try:
+        if timeout is None:
+            response = urllib.request.urlopen(request)
+        else:
+            response = urllib.request.urlopen(request, timeout=float(timeout))
+        with response:
+            payload = json.load(response)
+    except urllib.error.HTTPError as error:
+        raise ValueError(f"Confluent Schema Registry returned HTTP {error.code}") from error
+    except urllib.error.URLError as error:
+        raise ValueError("Confluent Schema Registry request failed") from error
+
+    if not isinstance(payload, Mapping):
+        raise TypeError("Confluent Schema Registry response must be an object")
+    schema = payload.get("schema")
+    if not isinstance(schema, str):
+        raise TypeError("Confluent Schema Registry response is missing string 'schema'")
+    schema_type = payload.get("schemaType", "AVRO")
+    if not isinstance(schema_type, str):
+        raise TypeError("Confluent Schema Registry response has invalid 'schemaType'")
+    response_subject = payload.get("subject", subject)
+    response_version = payload.get("version", requested_version)
+    schema_id = payload.get("id")
+    references = payload.get("references", [])
+    if not isinstance(response_subject, str) or not isinstance(response_version, (str, int)):
+        raise TypeError("Confluent Schema Registry response has invalid subject or version")
+    if schema_id is not None and not isinstance(schema_id, (str, int)):
+        raise TypeError("Confluent Schema Registry response has invalid schema ID")
+    if not isinstance(references, list) or not all(isinstance(reference, Mapping) for reference in references):
+        raise TypeError("Confluent Schema Registry response has invalid references")
+    return ConfluentSchemaDocument(
+        schema=schema,
+        schema_type=schema_type.upper(),
+        subject=response_subject,
+        version=str(response_version),
+        schema_id=str(schema_id) if schema_id is not None else None,
+        references=tuple(references),
+    )
+
+
+def _parse_reference(url: str) -> tuple[str, str]:
+    parsed = urlsplit(url)
+    if parsed.scheme != "confluent" or not parsed.netloc or parsed.query or parsed.fragment:
+        raise ValueError("Confluent schema URL must be confluent://SUBJECT/versions/VERSION")
+    parts = [unquote(part) for part in parsed.path.strip("/").split("/") if part]
+    if len(parts) != 2 or parts[0] != "versions" or not parts[1]:
+        raise ValueError("Confluent schema URL must be confluent://SUBJECT/versions/VERSION")
+    version = parts[1]
+    if version != "latest":
+        try:
+            number = int(version)
+        except ValueError as error:
+            raise ValueError("Confluent schema VERSION must be 'latest', -1, or a positive integer") from error
+        if number != -1 and not 1 <= number <= 2**31 - 1:
+            raise ValueError("Confluent schema VERSION must be 'latest', -1, or a positive integer")
+    return unquote(parsed.netloc), version

--- a/fsspec_data/converters.py
+++ b/fsspec_data/converters.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import importlib.metadata
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
+from typing import Any, TypeAlias
+
+from .xarray_zarr import xarray_to_zarr, zarr_to_xarray
+
+CONVERTER_ENTRY_POINT_GROUP = "fsspec_data.converters"
+ConverterHandler: TypeAlias = Callable[..., Any]
+
+
+@dataclass(frozen=True)
+class Converter:
+    source_type: str
+    target_type: str
+    handler: ConverterHandler = field(repr=False)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "source_type", _normalize_type(self.source_type))
+        object.__setattr__(self, "target_type", _normalize_type(self.target_type))
+        if not callable(self.handler):
+            raise TypeError("converter handler must be callable")
+
+    def convert(
+        self,
+        source: Any,
+        target: Any | None = None,
+        *,
+        source_options: Mapping[str, Any] | None = None,
+        target_options: Mapping[str, Any] | None = None,
+        conversion_options: Mapping[str, Any] | None = None,
+    ) -> Any:
+        return self.handler(
+            source,
+            target,
+            source_options=_copy_options(source_options, "source_options"),
+            target_options=_copy_options(target_options, "target_options"),
+            conversion_options=_copy_options(conversion_options, "conversion_options"),
+        )
+
+
+class ConverterRegistry:
+    def __init__(
+        self,
+        *,
+        entry_point_group: str = CONVERTER_ENTRY_POINT_GROUP,
+        discover_entry_points: bool = True,
+    ) -> None:
+        self.entry_point_group = entry_point_group
+        self.discover_entry_points = discover_entry_points
+        self._converters: dict[tuple[str, str], Converter] = {}
+        self._entry_points_loaded = False
+
+    def register(self, converter: Converter, *, replace: bool = False) -> None:
+        if not isinstance(converter, Converter):
+            raise TypeError("converter must be a Converter")
+        key = (converter.source_type, converter.target_type)
+        if key in self._converters and not replace:
+            raise ValueError(f"converter from {key[0]!r} to {key[1]!r} is already registered")
+        self._converters[key] = converter
+
+    def load_entry_points(self) -> None:
+        if self._entry_points_loaded or not self.discover_entry_points:
+            return
+        discovered: list[tuple[str, Converter]] = []
+        for entry_point in sorted(
+            importlib.metadata.entry_points(group=self.entry_point_group),
+            key=lambda item: (item.name, item.value),
+        ):
+            converter = entry_point.load()
+            if not isinstance(converter, Converter):
+                raise TypeError(f"converter entry point {entry_point.name!r} must load a Converter")
+            discovered.append((entry_point.name, converter))
+
+        keys = set(self._converters)
+        for name, converter in discovered:
+            key = (converter.source_type, converter.target_type)
+            if key in keys:
+                raise ValueError(f"converter entry point {name!r} duplicates the route from {key[0]!r} to {key[1]!r}")
+            keys.add(key)
+        self._converters.update(((converter.source_type, converter.target_type), converter) for _, converter in discovered)
+        self._entry_points_loaded = True
+
+    def get(self, source_type: str, target_type: str) -> Converter:
+        self.load_entry_points()
+        key = (_normalize_type(source_type), _normalize_type(target_type))
+        try:
+            return self._converters[key]
+        except KeyError as error:
+            raise ValueError(f"no converter registered from {key[0]!r} to {key[1]!r}") from error
+
+    def convert(
+        self,
+        source_type: str,
+        target_type: str,
+        source: Any,
+        target: Any | None = None,
+        *,
+        source_options: Mapping[str, Any] | None = None,
+        target_options: Mapping[str, Any] | None = None,
+        conversion_options: Mapping[str, Any] | None = None,
+    ) -> Any:
+        return self.get(source_type, target_type).convert(
+            source,
+            target,
+            source_options=source_options,
+            target_options=target_options,
+            conversion_options=conversion_options,
+        )
+
+
+def _normalize_type(value: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError("converter types must be non-empty strings")
+    return value.strip().lower()
+
+
+def _copy_options(value: Mapping[str, Any] | None, name: str) -> dict[str, Any]:
+    if value is None:
+        return {}
+    if not isinstance(value, Mapping):
+        raise TypeError(f"{name} must be a mapping")
+    return dict(value)
+
+
+XARRAY_TO_ZARR = Converter("xarray", "zarr", xarray_to_zarr)
+ZARR_TO_XARRAY = Converter("zarr", "xarray", zarr_to_xarray)
+
+DEFAULT_CONVERTERS = ConverterRegistry()
+DEFAULT_CONVERTERS.register(XARRAY_TO_ZARR)
+DEFAULT_CONVERTERS.register(ZARR_TO_XARRAY)

--- a/fsspec_data/filesystem.py
+++ b/fsspec_data/filesystem.py
@@ -1,15 +1,14 @@
 from __future__ import annotations
 
 import tempfile
-from collections.abc import Mapping, Sequence
 from typing import Any
 
-import pyarrow as pa
 from fsspec import AbstractFileSystem, filesystem
 from fsspec.core import url_to_fs
 from fsspec.implementations.chained import ChainedFileSystem
 
 from .interchange import DEFAULT_REGISTRY, DataFormat, InterchangeRequest, SchemaPolicy
+from .schema import SchemaInput, SchemaProvenance, normalize_schema, resolve_schema
 
 
 class DataFileSystem(ChainedFileSystem):
@@ -25,8 +24,8 @@ class DataFileSystem(ChainedFileSystem):
         fs: AbstractFileSystem | None = None,
         provided_format: DataFormat | str | None = None,
         requested_format: DataFormat | str | None = None,
-        provided_schema: pa.Schema | Mapping[str, Any] | Sequence[Mapping[str, Any]] | None = None,
-        requested_schema: pa.Schema | Mapping[str, Any] | Sequence[Mapping[str, Any]] | None = None,
+        provided_schema: SchemaInput = None,
+        requested_schema: SchemaInput = None,
         schema_policy: SchemaPolicy | str = SchemaPolicy.EXACT,
         batch_size: int = 1024,
         row_limit: int | None = None,
@@ -47,8 +46,10 @@ class DataFileSystem(ChainedFileSystem):
         self.fo = fs._strip_protocol(fo)
         self.provided_format = DataFormat(provided_format) if provided_format is not None else None
         self.requested_format = DataFormat(requested_format) if requested_format is not None else None
-        self.provided_schema = _schema_from_options(provided_schema)
-        self.requested_schema = _schema_from_options(requested_schema)
+        self.provided_schema = normalize_schema(provided_schema)
+        self.requested_schema = normalize_schema(requested_schema)
+        self.provided_schema_provenance: SchemaProvenance | None = None
+        self.requested_schema_provenance: SchemaProvenance | None = None
         self.schema_policy = SchemaPolicy(schema_policy)
         self.batch_size = batch_size
         self.row_limit = row_limit
@@ -100,19 +101,25 @@ class DataFileSystem(ChainedFileSystem):
     def _convert(self, path: str, output) -> None:
         provided_format = self.provided_format or _format_from_path(self.fo)
         requested_format = self.requested_format or _format_from_path(path)
+        resolved_provided = resolve_schema(self.provided_schema)
+        resolved_requested = resolve_schema(self.requested_schema)
+        provided_schema = resolved_provided.schema if resolved_provided is not None else None
+        requested_schema = resolved_requested.schema if resolved_requested is not None else None
+        self.provided_schema_provenance = resolved_provided.provenance if resolved_provided is not None else None
+        self.requested_schema_provenance = resolved_requested.provenance if resolved_requested is not None else None
         with self.fs.open(self.fo, "rb") as source:
             decoded = DEFAULT_REGISTRY.get(provided_format).iter_batches(
                 source,
-                schema=self.provided_schema,
+                schema=provided_schema,
                 batch_size=self.batch_size,
                 row_limit=self.row_limit,
                 byte_limit=self.byte_limit,
             )
-            if self.provided_schema is not None and not decoded.schema.equals(self.provided_schema, check_metadata=False):
+            if provided_schema is not None and not decoded.schema.equals(provided_schema, check_metadata=False):
                 raise ValueError("provided schema does not match the source schema")
 
-            provided_schema = self.provided_schema or decoded.schema
-            requested_schema = self.requested_schema or provided_schema
+            provided_schema = provided_schema or decoded.schema
+            requested_schema = requested_schema or provided_schema
             plan = InterchangeRequest(
                 provided_format,
                 requested_format,
@@ -141,32 +148,3 @@ def _format_from_path(path: str) -> DataFormat:
         return _SUFFIX_FORMATS[suffix]
     except KeyError as error:
         raise ValueError(f"cannot infer tabular format from path {path!r}") from error
-
-
-def _schema_from_options(
-    value: pa.Schema | Mapping[str, Any] | Sequence[Mapping[str, Any]] | None,
-) -> pa.Schema | None:
-    if value is None or isinstance(value, pa.Schema):
-        return value
-    fields = value.get("fields") if isinstance(value, Mapping) else value
-    if not isinstance(fields, Sequence) or isinstance(fields, (str, bytes)):
-        raise TypeError("schema options must contain a sequence of fields")
-    return pa.schema([_field_from_options(field) for field in fields])
-
-
-def _field_from_options(value: Mapping[str, Any]) -> pa.Field:
-    if not isinstance(value, Mapping):
-        raise TypeError("schema fields must be mappings")
-    try:
-        name = value["name"]
-        data_type = value["type"]
-    except KeyError as error:
-        raise ValueError(f"schema field is missing {error.args[0]!r}") from error
-    if not isinstance(name, str) or not isinstance(data_type, (str, pa.DataType)):
-        raise TypeError("schema field name and type must be strings or PyArrow data types")
-    if isinstance(data_type, str):
-        data_type = pa.type_for_alias(data_type)
-    nullable = value.get("nullable", True)
-    if not isinstance(nullable, bool):
-        raise TypeError("schema field nullable must be a boolean")
-    return pa.field(name, data_type, nullable=nullable)

--- a/fsspec_data/json_schema.py
+++ b/fsspec_data/json_schema.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any, cast
+
+import pyarrow as pa
+
+_UNSUPPORTED_KEYWORDS = (
+    "$dynamicRef",
+    "$ref",
+    "allOf",
+    "anyOf",
+    "contains",
+    "contentEncoding",
+    "contentMediaType",
+    "dependentSchemas",
+    "else",
+    "if",
+    "not",
+    "nullable",
+    "oneOf",
+    "patternProperties",
+    "prefixItems",
+    "then",
+    "unevaluatedItems",
+    "unevaluatedProperties",
+)
+_PRIMITIVE_TYPES = {
+    "boolean": pa.bool_(),
+    "integer": pa.int64(),
+    "null": pa.null(),
+    "number": pa.float64(),
+    "string": pa.string(),
+}
+
+
+def json_schema_to_arrow(value: Mapping[str, Any]) -> pa.Schema:
+    if not isinstance(value, Mapping):
+        raise TypeError("JSON Schema must contain an object")
+    kind, allows_null = _schema_kind(value, "$")
+    if kind != "object":
+        raise ValueError(f"JSON Schema root must have type 'object', got {kind!r}")
+    if allows_null:
+        raise ValueError("JSON Schema root cannot allow null")
+    return pa.schema(_object_fields(value, "$"))
+
+
+def _data_type(value: Mapping[str, Any], path: str) -> tuple[pa.DataType, bool]:
+    _reject_unsupported(value, path)
+    if "format" in value:
+        raise ValueError(f"unsupported JSON Schema at {path}: format {value['format']!r}")
+    kind, allows_null = _schema_kind(value, path)
+    if kind in _PRIMITIVE_TYPES:
+        return _PRIMITIVE_TYPES[kind], allows_null or kind == "null"
+    if kind == "array":
+        items = value.get("items")
+        if not isinstance(items, Mapping):
+            raise ValueError(f"unsupported JSON Schema at {path}: arrays require one object-valued 'items' schema")
+        item_type, item_nullable = _data_type(cast(Mapping[str, Any], items), f"{path}.items")
+        return pa.list_(pa.field("item", item_type, nullable=item_nullable)), allows_null
+    if kind == "object":
+        return pa.struct(_object_fields(value, path)), allows_null
+    raise ValueError(f"unsupported JSON Schema at {path}: type {kind!r}")
+
+
+def _object_fields(value: Mapping[str, Any], path: str) -> list[pa.Field]:
+    _reject_unsupported(value, path)
+    additional = value.get("additionalProperties")
+    if additional is not None and not isinstance(additional, bool):
+        raise ValueError(f"unsupported JSON Schema at {path}: schema-valued 'additionalProperties'")
+
+    properties = value.get("properties", {})
+    if not isinstance(properties, Mapping):
+        raise TypeError(f"JSON Schema at {path} has non-object 'properties'")
+    required = value.get("required", [])
+    if not isinstance(required, Sequence) or isinstance(required, (str, bytes)) or not all(isinstance(name, str) for name in required):
+        raise TypeError(f"JSON Schema at {path} has non-string 'required' entries")
+    required_names = set(required)
+    unknown_required = required_names - set(properties)
+    if unknown_required:
+        names = ", ".join(sorted(unknown_required))
+        raise ValueError(f"JSON Schema at {path} requires unknown properties: {names}")
+
+    fields = []
+    for name, property_schema in properties.items():
+        if not isinstance(name, str) or not isinstance(property_schema, Mapping):
+            raise TypeError(f"JSON Schema at {path} must map string property names to schema objects")
+        data_type, allows_null = _data_type(cast(Mapping[str, Any], property_schema), f"{path}.properties.{name}")
+        fields.append(pa.field(name, data_type, nullable=name not in required_names or allows_null))
+    return fields
+
+
+def _schema_kind(value: Mapping[str, Any], path: str) -> tuple[str, bool]:
+    _reject_unsupported(value, path)
+    raw_type = value.get("type")
+    if isinstance(raw_type, str):
+        types = [raw_type]
+    elif isinstance(raw_type, Sequence) and not isinstance(raw_type, (str, bytes)) and all(isinstance(item, str) for item in raw_type):
+        types = [cast(str, item) for item in raw_type]
+    else:
+        raise TypeError(f"JSON Schema at {path} requires a string or string-array 'type'")
+
+    distinct = list(dict.fromkeys(types))
+    unknown = set(distinct) - {*_PRIMITIVE_TYPES, "array", "object"}
+    if unknown:
+        raise ValueError(f"unsupported JSON Schema at {path}: type {min(unknown)!r}")
+    allows_null = "null" in distinct
+    non_null = [item for item in distinct if item != "null"]
+    if len(non_null) > 1:
+        raise ValueError(f"unsupported JSON Schema at {path}: unions may contain only one non-null type")
+    return (non_null[0] if non_null else "null"), allows_null
+
+
+def _reject_unsupported(value: Mapping[str, Any], path: str) -> None:
+    for keyword in _UNSUPPORTED_KEYWORDS:
+        if keyword in value:
+            raise ValueError(f"unsupported JSON Schema at {path}: keyword {keyword!r}")

--- a/fsspec_data/schema.py
+++ b/fsspec_data/schema.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass, field, replace
+from enum import Enum
+from typing import Any, TypeAlias, cast
+from urllib.parse import urlsplit
+
+import fsspec
+import pyarrow as pa
+
+from .confluent import fetch_confluent_schema
+from .json_schema import json_schema_to_arrow
+
+
+class SchemaFormat(str, Enum):
+    ARROW_IPC = "arrow-ipc-schema"
+    ARROW_JSON = "arrow-json"
+    JSON_SCHEMA = "json-schema"
+
+
+@dataclass(frozen=True)
+class SchemaRef:
+    url: str
+    format: SchemaFormat | str | None = None
+    storage_options: Mapping[str, Any] = field(default_factory=dict, repr=False)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.url, str) or not self.url:
+            raise ValueError("schema reference URL must be a non-empty string")
+        if self.format is not None:
+            object.__setattr__(self, "format", SchemaFormat(self.format))
+        if not isinstance(self.storage_options, Mapping):
+            raise TypeError("schema reference storage_options must be a mapping")
+        object.__setattr__(self, "storage_options", dict(self.storage_options))
+
+
+@dataclass(frozen=True)
+class SchemaProvenance:
+    source: str
+    format: str
+    provider: str
+    identifier: str | None = None
+    version: str | None = None
+
+
+@dataclass(frozen=True)
+class ResolvedSchema:
+    schema: pa.Schema
+    provenance: SchemaProvenance
+
+
+@dataclass(frozen=True)
+class SchemaDocument:
+    data: bytes
+    format: SchemaFormat
+    provenance: SchemaProvenance
+
+
+SchemaInput: TypeAlias = pa.Schema | SchemaRef | str | Mapping[str, Any] | Sequence[Mapping[str, Any]] | None
+SchemaDecoder: TypeAlias = Callable[[bytes], pa.Schema]
+SchemaProvider: TypeAlias = Callable[[SchemaRef], SchemaDocument]
+
+
+class SchemaResolverRegistry:
+    def __init__(self) -> None:
+        self._decoders: dict[SchemaFormat, SchemaDecoder] = {}
+        self._providers: dict[str, SchemaProvider] = {}
+
+    def register(self, format: SchemaFormat | str, decoder: SchemaDecoder) -> None:
+        self._decoders[SchemaFormat(format)] = decoder
+
+    def register_provider(self, protocol: str, provider: SchemaProvider) -> None:
+        self._providers[protocol.lower()] = provider
+
+    def resolve(self, reference: SchemaRef) -> ResolvedSchema:
+        protocol = urlsplit(reference.url).scheme.lower()
+        provider = self._providers.get(protocol, _resolve_fsspec_document)
+        document = provider(reference)
+        if reference.format is not None and SchemaFormat(reference.format) != document.format:
+            raise ValueError(f"schema reference requested {SchemaFormat(reference.format).value!r} but provider returned {document.format.value!r}")
+        try:
+            decoder = self._decoders[document.format]
+        except KeyError as error:
+            raise ValueError(f"no schema decoder registered for {document.format.value!r}") from error
+        return ResolvedSchema(
+            decoder(document.data),
+            replace(document.provenance, format=document.format.value),
+        )
+
+
+def normalize_schema(value: SchemaInput) -> pa.Schema | SchemaRef | None:
+    if value is None or isinstance(value, (pa.Schema, SchemaRef)):
+        return value
+    if isinstance(value, str):
+        return SchemaRef(value)
+    if isinstance(value, Mapping) and "url" in value:
+        unknown = set(value) - {"url", "format", "storage_options"}
+        if unknown:
+            raise ValueError(f"unknown schema reference options: {', '.join(sorted(unknown))}")
+        return SchemaRef(
+            url=value["url"],
+            format=value.get("format"),
+            storage_options=value.get("storage_options", {}),
+        )
+    return schema_from_options(value)
+
+
+def resolve_schema(
+    value: pa.Schema | SchemaRef | None,
+    registry: SchemaResolverRegistry | None = None,
+) -> ResolvedSchema | None:
+    if value is None:
+        return None
+    if isinstance(value, pa.Schema):
+        return ResolvedSchema(value, SchemaProvenance(source="inline", format="arrow", provider="inline"))
+    return (registry or DEFAULT_SCHEMA_RESOLVERS).resolve(value)
+
+
+def schema_from_options(value: Mapping[str, Any] | Sequence[Mapping[str, Any]]) -> pa.Schema:
+    fields = value.get("fields") if isinstance(value, Mapping) else value
+    if not isinstance(fields, Sequence) or isinstance(fields, (str, bytes)):
+        raise TypeError("schema options must contain a sequence of fields")
+    parsed_fields = []
+    for schema_field in fields:
+        if not isinstance(schema_field, Mapping):
+            raise TypeError("schema fields must be mappings")
+        parsed_fields.append(_field_from_options(cast(Mapping[str, Any], schema_field)))
+    return pa.schema(parsed_fields)
+
+
+def _field_from_options(value: Mapping[str, Any]) -> pa.Field:
+    if not isinstance(value, Mapping):
+        raise TypeError("schema fields must be mappings")
+    try:
+        name = value["name"]
+        data_type = value["type"]
+    except KeyError as error:
+        raise ValueError(f"schema field is missing {error.args[0]!r}") from error
+    if not isinstance(name, str) or not isinstance(data_type, (str, pa.DataType)):
+        raise TypeError("schema field name and type must be strings or PyArrow data types")
+    if isinstance(data_type, str):
+        data_type = pa.type_for_alias(data_type)
+    nullable = value.get("nullable", True)
+    if not isinstance(nullable, bool):
+        raise TypeError("schema field nullable must be a boolean")
+    return pa.field(name, data_type, nullable=nullable)
+
+
+def _format_from_url(url: str) -> SchemaFormat:
+    path = url.split("?", 1)[0].lower()
+    if path.endswith((".arrow", ".ipc", ".arrowschema")):
+        return SchemaFormat.ARROW_IPC
+    raise ValueError(f"schema format cannot be inferred from {url!r}; provide format explicitly")
+
+
+def _decode_arrow_json(data: bytes) -> pa.Schema:
+    value = json.loads(data)
+    if not isinstance(value, Mapping):
+        raise TypeError("Arrow JSON schema must contain an object")
+    return schema_from_options(value)
+
+
+def _decode_arrow_ipc(data: bytes) -> pa.Schema:
+    return pa.ipc.read_schema(pa.BufferReader(data))
+
+
+def _decode_json_schema(data: bytes) -> pa.Schema:
+    value = json.loads(data)
+    if not isinstance(value, Mapping):
+        raise TypeError("JSON Schema must contain an object")
+    return json_schema_to_arrow(value)
+
+
+def _resolve_fsspec_document(reference: SchemaRef) -> SchemaDocument:
+    format = SchemaFormat(reference.format) if reference.format is not None else _format_from_url(reference.url)
+    with fsspec.open(reference.url, "rb", **reference.storage_options) as file:
+        data = file.read()
+    return SchemaDocument(
+        data=data,
+        format=format,
+        provenance=SchemaProvenance(source=reference.url, format=format.value, provider="fsspec"),
+    )
+
+
+def _resolve_confluent_document(reference: SchemaRef) -> SchemaDocument:
+    document = fetch_confluent_schema(reference.url, reference.storage_options)
+    if document.references:
+        raise ValueError("Confluent schema references are not supported yet")
+    if document.schema_type != "JSON":
+        raise ValueError(f"Confluent schema type {document.schema_type!r} is not supported")
+    return SchemaDocument(
+        data=document.schema.encode(),
+        format=SchemaFormat.JSON_SCHEMA,
+        provenance=SchemaProvenance(
+            source=reference.url,
+            format=SchemaFormat.JSON_SCHEMA.value,
+            provider="confluent",
+            identifier=document.schema_id,
+            version=document.version,
+        ),
+    )
+
+
+DEFAULT_SCHEMA_RESOLVERS = SchemaResolverRegistry()
+DEFAULT_SCHEMA_RESOLVERS.register(SchemaFormat.ARROW_JSON, _decode_arrow_json)
+DEFAULT_SCHEMA_RESOLVERS.register(SchemaFormat.ARROW_IPC, _decode_arrow_ipc)
+DEFAULT_SCHEMA_RESOLVERS.register(SchemaFormat.JSON_SCHEMA, _decode_json_schema)
+DEFAULT_SCHEMA_RESOLVERS.register_provider("confluent", _resolve_confluent_document)

--- a/fsspec_data/tests/test_converters.py
+++ b/fsspec_data/tests/test_converters.py
@@ -1,0 +1,183 @@
+from types import SimpleNamespace
+
+import fsspec
+import pytest
+
+import fsspec_data.converters as converters_module
+import fsspec_data.xarray_zarr as xarray_zarr_module
+from fsspec_data import DEFAULT_CONVERTERS, Converter, ConverterRegistry
+
+
+def test_converter_registry_preserves_scoped_options():
+    received = []
+
+    def convert(source, target, **options):
+        received.append((source, target, options))
+        return "converted"
+
+    registry = ConverterRegistry(discover_entry_points=False)
+    registry.register(Converter(" Source ", "TARGET", convert))
+
+    result = registry.convert(
+        "source",
+        "target",
+        "input",
+        "output",
+        source_options={"source-token": "a"},
+        target_options={"target-token": "b"},
+        conversion_options={"mode": "safe"},
+    )
+
+    assert result == "converted"
+    assert received == [
+        (
+            "input",
+            "output",
+            {
+                "source_options": {"source-token": "a"},
+                "target_options": {"target-token": "b"},
+                "conversion_options": {"mode": "safe"},
+            },
+        )
+    ]
+
+
+def test_converter_registry_rejects_duplicate_route():
+    registry = ConverterRegistry(discover_entry_points=False)
+    converter = Converter("source", "target", lambda *args, **kwargs: None)
+    registry.register(converter)
+
+    with pytest.raises(ValueError, match="already registered"):
+        registry.register(converter)
+
+
+def test_converter_registry_loads_entry_points_lazily(monkeypatch):
+    loaded = []
+    converter = Converter("custom-source", "custom-target", lambda *args, **kwargs: "plugin")
+
+    class EntryPoint:
+        name = "custom"
+        value = "example.converter:CONVERTER"
+
+        def load(self):
+            loaded.append(self.name)
+            return converter
+
+    monkeypatch.setattr(
+        converters_module.importlib.metadata,
+        "entry_points",
+        lambda **selection: (EntryPoint(),),
+    )
+    registry = ConverterRegistry()
+
+    assert loaded == []
+    assert registry.convert("custom-source", "custom-target", "value") == "plugin"
+    assert loaded == ["custom"]
+    registry.get("custom-source", "custom-target")
+    assert loaded == ["custom"]
+
+
+def test_converter_registry_rejects_invalid_entry_point(monkeypatch):
+    entry_point = SimpleNamespace(name="invalid", value="example:invalid", load=lambda: object())
+    monkeypatch.setattr(
+        converters_module.importlib.metadata,
+        "entry_points",
+        lambda **selection: (entry_point,),
+    )
+
+    with pytest.raises(TypeError, match="entry point 'invalid' must load a Converter"):
+        ConverterRegistry().get("source", "target")
+
+
+def test_zarr_to_xarray_passes_source_credentials_and_conversion_options(monkeypatch):
+    calls = []
+    fake_xarray = SimpleNamespace(open_zarr=lambda source, **options: calls.append((source, options)) or "dataset")
+    monkeypatch.setattr(xarray_zarr_module, "import_module", lambda name: fake_xarray)
+
+    result = DEFAULT_CONVERTERS.convert(
+        "zarr",
+        "xarray",
+        "s3://bucket/weather.zarr",
+        source_options={"profile": "weather-reader"},
+        conversion_options={"group": "forecast", "chunks": None},
+    )
+
+    assert result == "dataset"
+    assert calls == [
+        (
+            "s3://bucket/weather.zarr",
+            {
+                "group": "forecast",
+                "chunks": None,
+                "storage_options": {"profile": "weather-reader"},
+            },
+        )
+    ]
+
+
+def test_xarray_to_zarr_passes_target_credentials_and_conversion_options(monkeypatch):
+    calls = []
+
+    class Dataset:
+        def to_zarr(self, **options):
+            calls.append(options)
+            return "store"
+
+    fake_xarray = SimpleNamespace(Dataset=Dataset, DataArray=type("DataArray", (), {}))
+    monkeypatch.setattr(xarray_zarr_module, "import_module", lambda name: fake_xarray)
+
+    result = DEFAULT_CONVERTERS.convert(
+        "xarray",
+        "zarr",
+        Dataset(),
+        "s3://bucket/weather.zarr",
+        target_options={"profile": "weather-writer"},
+        conversion_options={"mode": "w-", "zarr_format": 3},
+    )
+
+    assert result == "store"
+    assert calls == [
+        {
+            "store": "s3://bucket/weather.zarr",
+            "mode": "w-",
+            "zarr_format": 3,
+            "storage_options": {"profile": "weather-writer"},
+        }
+    ]
+
+
+def test_xarray_converter_reports_optional_dependency(monkeypatch):
+    def unavailable(name):
+        raise ModuleNotFoundError(name)
+
+    monkeypatch.setattr(xarray_zarr_module, "import_module", unavailable)
+
+    with pytest.raises(ImportError, match=r"fsspec-data\[xarray\]"):
+        DEFAULT_CONVERTERS.convert("zarr", "xarray", "memory://weather.zarr")
+
+
+def test_xarray_zarr_round_trip():
+    xarray = pytest.importorskip("xarray")
+    pytest.importorskip("zarr")
+    source = xarray.Dataset(
+        {"temperature": (("x", "y"), [[1.0, 2.0], [3.0, 4.0]])},
+        coords={"x": [10, 20], "y": [30, 40]},
+        attrs={"units": "K"},
+    )
+    store = fsspec.get_mapper("memory://weather.zarr")
+
+    DEFAULT_CONVERTERS.convert(
+        "xarray",
+        "zarr",
+        source,
+        store,
+        conversion_options={"mode": "w", "zarr_format": 3, "consolidated": False},
+    )
+    result = DEFAULT_CONVERTERS.convert(
+        "zarr",
+        "xarray",
+        store,
+        conversion_options={"chunks": None, "consolidated": False},
+    )
+
+    xarray.testing.assert_identical(result, source)

--- a/fsspec_data/tests/test_schema.py
+++ b/fsspec_data/tests/test_schema.py
@@ -1,0 +1,406 @@
+import io
+import json
+
+import fsspec
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+import fsspec_data.confluent as confluent_module
+import fsspec_data.schema as schema_module
+from fsspec_data import DataFileSystem, SchemaRef, json_schema_to_arrow, resolve_schema
+
+SOURCE_SCHEMA = pa.schema(
+    [
+        pa.field("id", pa.int64(), nullable=False),
+        pa.field("name", pa.string()),
+    ]
+)
+TARGET_SCHEMA = pa.schema([pa.field("name", pa.string())])
+SOURCE_SCHEMA_JSON = {
+    "fields": [
+        {"name": "id", "type": "int64", "nullable": False},
+        {"name": "name", "type": "string", "nullable": True},
+    ]
+}
+SOURCE_JSON_SCHEMA = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+        "id": {"type": "integer"},
+        "name": {"type": "string"},
+    },
+    "required": ["id", "name"],
+    "additionalProperties": False,
+}
+TARGET_JSON_SCHEMA = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {"name": {"type": "string"}},
+    "required": ["name"],
+    "additionalProperties": False,
+}
+
+
+def test_schema_reference_hides_storage_options_from_repr():
+    reference = SchemaRef(
+        "s3://schemas/source.json",
+        format="arrow-json",
+        storage_options={"secret": "do-not-display"},
+    )
+
+    assert "do-not-display" not in repr(reference)
+
+
+def test_arrow_ipc_schema_format_is_inferred(monkeypatch):
+    monkeypatch.setattr(
+        schema_module.fsspec,
+        "open",
+        lambda url, mode, **options: io.BytesIO(SOURCE_SCHEMA.serialize().to_pybytes()),
+    )
+
+    resolved = resolve_schema(SchemaRef("memory://schemas/source.arrow"))
+
+    assert resolved is not None
+    assert resolved.schema.equals(SOURCE_SCHEMA)
+    assert resolved.provenance.source == "memory://schemas/source.arrow"
+    assert resolved.provenance.format == "arrow-ipc-schema"
+
+
+def test_schema_reference_requires_format_for_ambiguous_extension():
+    with pytest.raises(ValueError, match="schema format cannot be inferred"):
+        resolve_schema(SchemaRef("memory://schemas/source.json"))
+
+
+def test_json_schema_maps_structural_types_and_nullability():
+    schema = json_schema_to_arrow(
+        {
+            "type": "object",
+            "properties": {
+                "id": {"type": "integer"},
+                "name": {"type": ["string", "null"]},
+                "score": {"type": "number", "minimum": 0},
+                "flags": {"type": "array", "items": {"type": "boolean"}},
+                "profile": {
+                    "type": "object",
+                    "properties": {
+                        "active": {"type": "boolean"},
+                        "note": {"type": "string"},
+                    },
+                    "required": ["active"],
+                },
+            },
+            "required": ["id", "name", "flags", "profile"],
+        }
+    )
+
+    expected = pa.schema(
+        [
+            pa.field("id", pa.int64(), nullable=False),
+            pa.field("name", pa.string()),
+            pa.field("score", pa.float64()),
+            pa.field("flags", pa.list_(pa.field("item", pa.bool_(), nullable=False)), nullable=False),
+            pa.field(
+                "profile",
+                pa.struct(
+                    [
+                        pa.field("active", pa.bool_(), nullable=False),
+                        pa.field("note", pa.string()),
+                    ]
+                ),
+                nullable=False,
+            ),
+        ]
+    )
+
+    assert schema.equals(expected, check_metadata=False)
+
+
+def test_data_filesystem_resolves_independent_schema_sources(monkeypatch):
+    opened = []
+
+    def open_schema(url, mode, **storage_options):
+        opened.append((url, mode, storage_options))
+        if url.endswith("source.json"):
+            return io.BytesIO(json.dumps(SOURCE_SCHEMA_JSON).encode())
+        if url.endswith("target.arrow"):
+            return io.BytesIO(TARGET_SCHEMA.serialize().to_pybytes())
+        raise AssertionError(url)
+
+    monkeypatch.setattr(schema_module.fsspec, "open", open_schema)
+    source_fs = fsspec.filesystem("memory")
+    source_fs.store.clear()
+    source_fs.pipe("orders.csv", b"id,name\n1,ada\n2,grace\n")
+    fs = DataFileSystem(
+        fo="orders.csv",
+        fs=source_fs,
+        provided_schema={
+            "url": "memory://schemas/source.json",
+            "format": "arrow-json",
+            "storage_options": {"token": "provided-token"},
+        },
+        requested_schema={
+            "url": "memory://schemas/target.arrow",
+            "format": "arrow-ipc-schema",
+            "storage_options": {"token": "requested-token"},
+        },
+        schema_policy="projection",
+    )
+
+    result = pq.read_table(fs.open("orders.parquet"))
+
+    assert result.schema.equals(TARGET_SCHEMA, check_metadata=False)
+    assert result.to_pylist() == [{"name": "ada"}, {"name": "grace"}]
+    assert opened == [
+        ("memory://schemas/source.json", "rb", {"token": "provided-token"}),
+        ("memory://schemas/target.arrow", "rb", {"token": "requested-token"}),
+    ]
+    assert fs.provided_schema_provenance is not None
+    assert fs.requested_schema_provenance is not None
+    assert fs.provided_schema_provenance.source == "memory://schemas/source.json"
+    assert fs.requested_schema_provenance.source == "memory://schemas/target.arrow"
+
+
+def test_fsspec_open_resolves_referenced_schemas():
+    memory_fs = fsspec.filesystem("memory")
+    memory_fs.store.clear()
+    memory_fs.pipe("orders.csv", b"id,name\n1,ada\n2,grace\n")
+    memory_fs.pipe("schemas/source.json", json.dumps(SOURCE_SCHEMA_JSON).encode())
+    memory_fs.pipe("schemas/target.arrow", TARGET_SCHEMA.serialize().to_pybytes())
+    fsspec.register_implementation("fsspec-data", DataFileSystem, clobber=True)
+
+    with fsspec.open(
+        "fsspec-data://orders.parquet::memory://orders.csv",
+        provided_schema={
+            "url": "memory://schemas/source.json",
+            "format": "arrow-json",
+        },
+        requested_schema="memory://schemas/target.arrow",
+        schema_policy="projection",
+    ) as file:
+        result = pq.read_table(file)
+
+    assert result.schema.equals(TARGET_SCHEMA, check_metadata=False)
+    assert result.to_pylist() == [{"name": "ada"}, {"name": "grace"}]
+
+
+def test_fsspec_open_resolves_json_schemas():
+    memory_fs = fsspec.filesystem("memory")
+    memory_fs.store.clear()
+    memory_fs.pipe("orders.csv", b"id,name\n1,ada\n2,grace\n")
+    memory_fs.pipe("schemas/source.schema.json", json.dumps(SOURCE_JSON_SCHEMA).encode())
+    memory_fs.pipe("schemas/target.schema.json", json.dumps(TARGET_JSON_SCHEMA).encode())
+    fsspec.register_implementation("fsspec-data", DataFileSystem, clobber=True)
+
+    with fsspec.open(
+        "fsspec-data://orders.parquet::memory://orders.csv",
+        provided_schema={
+            "url": "memory://schemas/source.schema.json",
+            "format": "json-schema",
+        },
+        requested_schema={
+            "url": "memory://schemas/target.schema.json",
+            "format": "json-schema",
+        },
+        schema_policy="projection",
+    ) as file:
+        result = pq.read_table(file)
+
+    assert result.schema.equals(json_schema_to_arrow(TARGET_JSON_SCHEMA), check_metadata=False)
+    assert result.to_pylist() == [{"name": "ada"}, {"name": "grace"}]
+
+
+def test_confluent_resolver_fetches_json_schema_with_scoped_credentials(monkeypatch):
+    requests = []
+
+    def urlopen(request, *, timeout):
+        requests.append((request, timeout))
+        return io.BytesIO(
+            json.dumps(
+                {
+                    "subject": "orders-value",
+                    "version": 7,
+                    "id": 42,
+                    "schemaType": "JSON",
+                    "schema": json.dumps(SOURCE_JSON_SCHEMA),
+                }
+            ).encode()
+        )
+
+    monkeypatch.setattr(confluent_module.urllib.request, "urlopen", urlopen)
+    reference = SchemaRef(
+        "confluent://orders-value/versions/latest",
+        format="json-schema",
+        storage_options={
+            "registry_url": "https://schemas.example.test",
+            "username": "schema-key",
+            "password": "schema-secret",
+            "headers": {"X-Tenant": "analytics"},
+            "timeout": 3,
+        },
+    )
+
+    resolved = resolve_schema(reference)
+
+    assert resolved is not None
+    assert resolved.schema.equals(json_schema_to_arrow(SOURCE_JSON_SCHEMA), check_metadata=False)
+    assert resolved.provenance.source == "confluent://orders-value/versions/latest"
+    assert resolved.provenance.format == "json-schema"
+    assert resolved.provenance.provider == "confluent"
+    assert resolved.provenance.identifier == "42"
+    assert resolved.provenance.version == "7"
+    assert "schema-secret" not in repr(reference)
+    assert "schema-secret" not in repr(resolved.provenance)
+    assert len(requests) == 1
+    request, timeout = requests[0]
+    assert request.full_url == "https://schemas.example.test/subjects/orders-value/versions/latest"
+    assert request.get_header("Authorization") == "Basic c2NoZW1hLWtleTpzY2hlbWEtc2VjcmV0"
+    assert request.get_header("X-tenant") == "analytics"
+    assert timeout == 3.0
+
+
+def test_fsspec_open_composes_confluent_schema_with_file_schema(monkeypatch):
+    monkeypatch.setattr(
+        confluent_module.urllib.request,
+        "urlopen",
+        lambda request: io.BytesIO(
+            json.dumps(
+                {
+                    "subject": "orders-value",
+                    "version": 7,
+                    "id": 42,
+                    "schemaType": "JSON",
+                    "schema": json.dumps(SOURCE_JSON_SCHEMA),
+                }
+            ).encode()
+        ),
+    )
+    memory_fs = fsspec.filesystem("memory")
+    memory_fs.store.clear()
+    memory_fs.pipe("orders.csv", b"id,name\n1,ada\n2,grace\n")
+    memory_fs.pipe("schemas/target.schema.json", json.dumps(TARGET_JSON_SCHEMA).encode())
+    fsspec.register_implementation("fsspec-data", DataFileSystem, clobber=True)
+
+    with fsspec.open(
+        "fsspec-data://orders.parquet::memory://orders.csv",
+        provided_schema={
+            "url": "confluent://orders-value/versions/latest",
+            "format": "json-schema",
+            "storage_options": {"registry_url": "https://schemas.example.test"},
+        },
+        requested_schema={
+            "url": "memory://schemas/target.schema.json",
+            "format": "json-schema",
+        },
+        schema_policy="projection",
+    ) as file:
+        result = pq.read_table(file)
+
+    assert result.schema.equals(json_schema_to_arrow(TARGET_JSON_SCHEMA), check_metadata=False)
+    assert result.to_pylist() == [{"name": "ada"}, {"name": "grace"}]
+
+
+@pytest.mark.parametrize(
+    ("payload", "message"),
+    [
+        ({"schemaType": "AVRO", "schema": "{}"}, "schema type 'AVRO' is not supported"),
+        (
+            {
+                "schemaType": "JSON",
+                "schema": json.dumps(SOURCE_JSON_SCHEMA),
+                "references": [{"name": "base", "subject": "base", "version": 1}],
+            },
+            "schema references are not supported yet",
+        ),
+    ],
+)
+def test_confluent_resolver_rejects_unsupported_documents(monkeypatch, payload, message):
+    monkeypatch.setattr(
+        confluent_module.urllib.request,
+        "urlopen",
+        lambda request: io.BytesIO(json.dumps(payload).encode()),
+    )
+
+    with pytest.raises(ValueError, match=message):
+        resolve_schema(
+            SchemaRef(
+                "confluent://orders-value/versions/latest",
+                storage_options={"registry_url": "https://schemas.example.test"},
+            )
+        )
+
+
+def test_confluent_resolver_requires_registry_url():
+    with pytest.raises(ValueError, match=r"require storage_options\['registry_url'\]"):
+        resolve_schema(SchemaRef("confluent://orders-value/versions/latest"))
+
+
+def test_confluent_resolver_rejects_invalid_version():
+    with pytest.raises(ValueError, match="VERSION must be 'latest', -1, or a positive integer"):
+        resolve_schema(
+            SchemaRef(
+                "confluent://orders-value/versions/newest",
+                storage_options={"registry_url": "https://schemas.example.test"},
+            )
+        )
+
+
+@pytest.mark.parametrize(
+    ("schema", "message"),
+    [
+        (
+            {"type": "object", "properties": {"value": {"anyOf": [{"type": "integer"}, {"type": "string"}]}}},
+            r"\$.properties.value: keyword 'anyOf'",
+        ),
+        (
+            {"type": "object", "properties": {"value": {"type": ["integer", "string"]}}},
+            r"\$.properties.value: unions may contain only one non-null type",
+        ),
+        (
+            {"type": "object", "properties": {"created": {"type": "string", "format": "date-time"}}},
+            r"\$.properties.created: format 'date-time'",
+        ),
+        (
+            {"type": "object", "properties": {"value": {"$ref": "#/$defs/value"}}},
+            r"\$.properties.value: keyword '\$ref'",
+        ),
+        (
+            {"type": "object", "additionalProperties": {"type": "string"}},
+            r"\$: schema-valued 'additionalProperties'",
+        ),
+        (
+            {"type": "object", "properties": {}, "required": ["missing"]},
+            r"\$ requires unknown properties: missing",
+        ),
+    ],
+)
+def test_json_schema_rejects_ambiguous_constructs(schema, message):
+    with pytest.raises(ValueError, match=message):
+        json_schema_to_arrow(schema)
+
+
+def test_schema_resolution_precedes_source_read(monkeypatch):
+    monkeypatch.setattr(
+        schema_module.fsspec,
+        "open",
+        lambda url, mode, **options: (_ for _ in ()).throw(ValueError("schema unavailable")),
+    )
+    source_fs = fsspec.filesystem("memory")
+    monkeypatch.setattr(source_fs, "open", lambda *args, **kwargs: pytest.fail("source data must not be opened"))
+    fs = DataFileSystem(
+        fo="orders.csv",
+        fs=source_fs,
+        provided_schema={"url": "memory://schemas/source.json", "format": "arrow-json"},
+    )
+
+    with pytest.raises(ValueError, match="schema unavailable"):
+        fs.open("orders.parquet")
+
+
+def test_schema_reference_rejects_unknown_options():
+    with pytest.raises(ValueError, match="unknown schema reference options: credentials"):
+        DataFileSystem(
+            fo="orders.csv",
+            fs=fsspec.filesystem("memory"),
+            provided_schema={"url": "memory://schemas/source.arrow", "credentials": {}},
+        )

--- a/fsspec_data/xarray_zarr.py
+++ b/fsspec_data/xarray_zarr.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from importlib import import_module
+from typing import Any
+
+
+def zarr_to_xarray(
+    source: Any,
+    target: Any | None,
+    *,
+    source_options: Mapping[str, Any],
+    target_options: Mapping[str, Any],
+    conversion_options: Mapping[str, Any],
+) -> Any:
+    if target is not None:
+        raise ValueError("zarr-to-xarray conversion returns an object and does not accept a target")
+    if target_options:
+        raise ValueError("zarr-to-xarray conversion does not accept target_options")
+    options = dict(conversion_options)
+    _add_storage_options(options, source_options)
+    return _import_xarray().open_zarr(source, **options)
+
+
+def xarray_to_zarr(
+    source: Any,
+    target: Any | None,
+    *,
+    source_options: Mapping[str, Any],
+    target_options: Mapping[str, Any],
+    conversion_options: Mapping[str, Any],
+) -> Any:
+    xarray = _import_xarray()
+    if not isinstance(source, (xarray.Dataset, xarray.DataArray)):
+        raise TypeError("xarray-to-zarr conversion requires an xarray Dataset or DataArray")
+    if source_options:
+        raise ValueError("xarray-to-zarr conversion does not accept source_options")
+    options = dict(conversion_options)
+    _add_storage_options(options, target_options)
+    return source.to_zarr(store=target, **options)
+
+
+def _add_storage_options(options: dict[str, Any], storage_options: Mapping[str, Any]) -> None:
+    if storage_options and "storage_options" in options:
+        raise ValueError("provide storage options through source_options or target_options, not conversion_options")
+    if storage_options:
+        options["storage_options"] = dict(storage_options)
+
+
+def _import_xarray():
+    try:
+        return import_module("xarray")
+    except ImportError as error:
+        raise ImportError("Xarray/Zarr conversion requires 'fsspec-data[xarray]'") from error

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,10 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+xarray = [
+    "xarray",
+    "zarr",
+]
 develop = [
     "build",
     "bump-my-version",


### PR DESCRIPTION
## Description

Adds independently resolvable provided and requested schemas with fsspec, Arrow IPC, structural JSON Schema, and Confluent Schema Registry providers. Schema credentials remain scoped to each reference and provenance is recorded before source data is opened.

Adds a native converter registry with lazy entry-point discovery plus optional Xarray-to-Zarr and Zarr-to-Xarray routes. Updates API, how-to, and explanation docs with the canonical data, schema, projection, codec, and native-converter flow.

Confluent support currently accepts JSON Schema documents without external references. Zarr remains a native multi-object resource conversion rather than a DataFileSystem single-file codec.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Documentation update
- [ ] Refactor / code cleanup
- [ ] CI / build configuration
- [ ] Other (describe below)

## Checklist

- [x] Linting passes (make lint)
- [x] Tests pass (make test)
- [x] New tests added for new functionality
- [x] Documentation updated (if applicable)
- [x] Changelog / version bump (not applicable; no release requested)